### PR TITLE
avg count zero bug prevents diffexp

### DIFF
--- a/lib/process.py
+++ b/lib/process.py
@@ -900,7 +900,7 @@ class Alignment:
             for line in sf:
                 if "average length:" in line: 
                     line = line.strip().split()
-                    avg_length = line[-1]
+                    avg_len = line[-1]
                     break
         return avg_len 
 


### PR DESCRIPTION
fixing average length counting bug. this would be revealed by pep8 build of unused initialized variables. the lack of correct return keeps diffexp from running