### PR TITLE
added Github action to run flake8 linter, and did some code cleanup (black and manually)

### DIFF
--- a/.github/workflows/flake8_lint.yml
+++ b/.github/workflows/flake8_lint.yml
@@ -1,0 +1,17 @@
+name: flake8 Lint
+
+on: [push, pull_request]
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Set up Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2

--- a/.github/workflows/flake8_lint.yml
+++ b/.github/workflows/flake8_lint.yml
@@ -16,4 +16,4 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
-          ignore: "E231,E225,E501"
+          ignore: "E501"

--- a/.github/workflows/flake8_lint.yml
+++ b/.github/workflows/flake8_lint.yml
@@ -16,4 +16,4 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
-          ignore: "E231,E225"
+          ignore: "E231,E225,E501"

--- a/.github/workflows/flake8_lint.yml
+++ b/.github/workflows/flake8_lint.yml
@@ -15,3 +15,5 @@ jobs:
           python-version: "3.11"
       - name: flake8 Lint
         uses: py-actions/flake8@v2
+        with:
+          ignore: "E231,E225"

--- a/lib/experiment.py
+++ b/lib/experiment.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python3
 
-import sys, os, subprocess
-import requests
-import json, io
+import sys
+import os
+import subprocess
+import json
+import io
 import bvbrc_api as bvb
 
 
@@ -37,7 +39,7 @@ class Genome:
         self.genome_id = gi
         self.genome_ref_id = gi
         self.genome_type = gt
-        if not self.genome_type in self.valid_genome_types:
+        if self.genome_type not in self.valid_genome_types:
             print(
                 "{0} is not a valid genome type:\n{1}".format(
                     self.genome_type, ",".join(self.valid_genome_types)
@@ -48,7 +50,7 @@ class Genome:
         self.genome_data = {}
         # get genome id prefix
         if genome_query:
-            base = f"https://www.bv-brc.org/api/genome/?"
+            base = "https://www.bv-brc.org/api/genome/?"
             query = f"eq(genome_id,{gi})"
             headers = {
                 "accept": "application/json",
@@ -79,7 +81,7 @@ class Genome:
         #    print("{0} not a valid genome data type:\n{1}".format(key,",".join(self.valid_data_types)))
 
     def get_genome_data(self, key):
-        if not key in self.genome_data:
+        if key not in self.genome_data:
             print("{0} not in genome {1}".format(key, self.genome_id))
             return None
         else:

--- a/lib/experiment.py
+++ b/lib/experiment.py
@@ -132,7 +132,7 @@ class Genome:
                 # return True
             except Exception as e:
                 sys.stderr.write(
-                    "bowtie build failed for genome {0}\n".format(self.get_id())
+                    f"bowtie build failed for genome {self.get_id()}\n"
                 )
                 print("error: {0}".format(e))
                 return False
@@ -237,7 +237,7 @@ class Sample:
         self.sample_id = si
         self.sample_type = st
         # TODO: change sample type based on SRA single or paired
-        if not self.sample_type in self.valid_sample_types:
+        if self.sample_type not in self.valid_sample_types:
             print(
                 "{0} not a valid sample type: {1}".format(
                     self.sample_type, ",".join(self.valid_sample_types)
@@ -273,7 +273,7 @@ class Sample:
         self.sample_data[key] = data
 
     def get_sample_data(self, key):
-        if not key in self.sample_data:
+        if key not in self.sample_data:
             print("{0} not in sample {1}".format(key, self.sample_id))
             return None
         else:

--- a/lib/experiment.py
+++ b/lib/experiment.py
@@ -5,67 +5,85 @@ import requests
 import json, io
 import bvbrc_api as bvb
 
-class Genome:
 
-    valid_data_types = ["fasta","annotation","bed","hisat_index","hisat_prefix","bowtie_prefix","counts_table","merged_gtf","sample_metadata_file"]
-    valid_genome_types = ["bacteria","host"]
+class Genome:
+    valid_data_types = [
+        "fasta",
+        "annotation",
+        "bed",
+        "hisat_index",
+        "hisat_prefix",
+        "bowtie_prefix",
+        "counts_table",
+        "merged_gtf",
+        "sample_metadata_file",
+    ]
+    valid_genome_types = ["bacteria", "host"]
     # if genome_type is bacteria: HTSeq quant
     # if genome_type is host: Stringtie quant
-    # if cufflinks==true in job_data, run old pipeline 
+    # if cufflinks==true in job_data, run old pipeline
 
     genome_id = None
     genome_ref_id = None
-    genome_name = None #TODO: incorporate into paths
-    genome_type = None #bacteria or host    
+    genome_name = None  # TODO: incorporate into paths
+    genome_type = None  # bacteria or host
     genome_dir = None
-    genome_data = None # Dictionary that holds fasta, annotation, hisat index, etc
+    genome_data = None  # Dictionary that holds fasta, annotation, hisat index, etc
     sample_path_dict = None
 
-    def __init__(self, gi, gt, session, genome_query = True):
+    def __init__(self, gi, gt, session, genome_query=True):
         self.genome_id = gi
         self.genome_ref_id = gi
         self.genome_type = gt
         if not self.genome_type in self.valid_genome_types:
-            print("{0} is not a valid genome type:\n{1}".format(self.genome_type, ",".join(self.valid_genome_types))) 
+            print(
+                "{0} is not a valid genome type:\n{1}".format(
+                    self.genome_type, ",".join(self.valid_genome_types)
+                )
+            )
             return None
         self.sample_path_dict = {}
         self.genome_data = {}
         # get genome id prefix
         if genome_query:
-            base = f'https://www.bv-brc.org/api/genome/?'
-            query = f'eq(genome_id,{gi})'
-            headers = {"accept":"application/json", "content-type":"application/rqlquery+x-www-form-urlencoded", 'Authorization': session.headers['Authorization']}
-            print('genome_query:\nurl = {0}\n{1}\n'.format(base+query,headers))
-            genome_res = bvb.getQueryDataText(base,query,headers) 
-            #res['response']['docs'][0]['common_name']
+            base = f"https://www.bv-brc.org/api/genome/?"
+            query = f"eq(genome_id,{gi})"
+            headers = {
+                "accept": "application/json",
+                "content-type": "application/rqlquery+x-www-form-urlencoded",
+                "Authorization": session.headers["Authorization"],
+            }
+            print("genome_query:\nurl = {0}\n{1}\n".format(base + query, headers))
+            genome_res = bvb.getQueryDataText(base, query, headers)
+            # res['response']['docs'][0]['common_name']
             response_json = json.load(io.StringIO(genome_res))
             if len(response_json) == 0:
                 self.genome_name = self.genome_id
             else:
-                if 'common_name' in response_json[0]:
-                    self.genome_name = response_json[0]['common_name']
+                if "common_name" in response_json[0]:
+                    self.genome_name = response_json[0]["common_name"]
                 else:
                     self.genome_name = self.genome_id
         else:
             self.genome_name = self.genome_id
 
-    def add_genome_data(self,key,data):
+    def add_genome_data(self, key, data):
         # TODO: (maybe not)check if key is valid
-        #if key in self.valid_data_types: 
+        # if key in self.valid_data_types:
         self.genome_data[key] = data
-        #else:
+        # else:
         #    print("{0} not a valid genome data type:\n{1}".format(key,",".join(self.valid_data_types)))
 
-    def get_genome_data(self,key):
+    def get_genome_data(self, key):
         if not key in self.genome_data:
             print("{0} not in genome {1}".format(key, self.genome_id))
             return None
         else:
             return self.genome_data[key]
 
-    def set_genome_dir(self,gd):
+    def set_genome_dir(self, gd):
         self.genome_dir = gd
-    
+
     def get_genome_dir(self):
         return self.genome_dir
 
@@ -84,7 +102,7 @@ class Genome:
     def get_path_dict(self):
         return self.sample_path_dict
 
-    def get_sample_path(self,sample_id):
+    def get_sample_path(self, sample_id):
         if sample_id in self.sample_path_dict:
             return self.sample_path_dict[sample_id]
         else:
@@ -93,96 +111,117 @@ class Genome:
     def get_genome_type(self):
         return self.genome_type
 
-    def create_path_entry(self,sample_id,path):
-        self.sample_path_dict[sample_id] = path 
+    def create_path_entry(self, sample_id, path):
+        self.sample_path_dict[sample_id] = path
 
     def setup_genome_database(self):
         if self.genome_type == "bacteria":
             # setup bowtie index
-            index_prefix = os.path.join(self.get_genome_dir(),self.get_id()) # TODO: check to make sure it's correct
-            bowtie_build_cmd = ["bowtie2-build",self.get_genome_data("fasta"),index_prefix]
+            index_prefix = os.path.join(
+                self.get_genome_dir(), self.get_id()
+            )  # TODO: check to make sure it's correct
+            bowtie_build_cmd = [
+                "bowtie2-build",
+                self.get_genome_data("fasta"),
+                index_prefix,
+            ]
             try:
                 print(" ".join(bowtie_build_cmd))
                 subprocess.check_call(bowtie_build_cmd)
-                self.add_genome_data("bowtie_prefix",index_prefix)
+                self.add_genome_data("bowtie_prefix", index_prefix)
                 # return True
             except Exception as e:
-                sys.stderr.write("bowtie build failed for genome {0}\n".format(self.get_id()))
+                sys.stderr.write(
+                    "bowtie build failed for genome {0}\n".format(self.get_id())
+                )
                 print("error: {0}".format(e))
                 return False
         elif self.genome_type == "host":
             print(self.genome_data)
-            index_prefix = os.path.join(self.get_genome_dir(),os.path.basename(self.get_genome_data('hisat_index').replace('.ht2.tar','')))
-            tar_cmd = ["tar","-xvf",self.get_genome_data('hisat_index'),'-C',os.path.dirname(self.get_genome_data('hisat_index'))]
+            index_prefix = os.path.join(
+                self.get_genome_dir(),
+                os.path.basename(
+                    self.get_genome_data("hisat_index").replace(".ht2.tar", "")
+                ),
+            )
+            tar_cmd = [
+                "tar",
+                "-xvf",
+                self.get_genome_data("hisat_index"),
+                "-C",
+                os.path.dirname(self.get_genome_data("hisat_index")),
+            ]
             try:
-                print('unpacking hisat2 index:\n{0}'.format(' '.join(tar_cmd)))
+                print("unpacking hisat2 index:\n{0}".format(" ".join(tar_cmd)))
                 subprocess.check_call(tar_cmd)
-                print('finished unpcking hisat2 index')
+                print("finished unpcking hisat2 index")
             except Exception as e:
-                sys.stderr.write('Error unpacking hisat2 index: exiting')
-                print('error: {0}'.format(e))
+                sys.stderr.write("Error unpacking hisat2 index: exiting")
+                print("error: {0}".format(e))
                 sys.exit(-1)
-            self.add_genome_data('hisat_prefix',index_prefix)
+            self.add_genome_data("hisat_prefix", index_prefix)
         # setup bed file
-        bed_file = self.get_genome_data("annotation").replace(".gff",".bed")
+        bed_file = self.get_genome_data("annotation").replace(".gff", ".bed")
         # TODO: add --do-not-sort after gff2bed?
         bed_cmd = "gff2bed < " + self.get_genome_data("annotation")
         try:
             print(bed_cmd)
-            with open(bed_file,"w") as bf:
-                subprocess.check_call(bed_cmd,stdout=bf,shell=True)
-            self.add_genome_data("bed",bed_file) 
+            with open(bed_file, "w") as bf:
+                subprocess.check_call(bed_cmd, stdout=bf, shell=True)
+            self.add_genome_data("bed", bed_file)
         except Exception as e:
-            sys.stderr.write("bed file generation failed for genome {0}\n".format(self.get_id()))
+            sys.stderr.write(
+                "bed file generation failed for genome {0}\n".format(self.get_id())
+            )
             print("error: {0}".format(e))
             return False
 
         # setup gtf file
-        #TPMCalculator -g ~/Genomes/9606/GCF_000001405.39_GRCh38.p13_genomic.mod.gtf -b Test_Htseq/9606/avirulent/replicate1/SRR10307420.bam -e
-        gff_to_gtf_cmd = ['gffread',self.get_genome_data('annotation'),'-T','-o-']
-        gtf_output = self.get_genome_data('annotation').replace('.gff','.gtf')
+        # TPMCalculator -g ~/Genomes/9606/GCF_000001405.39_GRCh38.p13_genomic.mod.gtf -b Test_Htseq/9606/avirulent/replicate1/SRR10307420.bam -e
+        gff_to_gtf_cmd = ["gffread", self.get_genome_data("annotation"), "-T", "-o-"]
+        gtf_output = self.get_genome_data("annotation").replace(".gff", ".gtf")
         try:
-            print(' '.join(gff_to_gtf_cmd))
-            gtg_proc = subprocess.Popen(gff_to_gtf_cmd,stdout=subprocess.PIPE)
+            print(" ".join(gff_to_gtf_cmd))
+            gtg_proc = subprocess.Popen(gff_to_gtf_cmd, stdout=subprocess.PIPE)
             gtf_text = gtg_proc.stdout.read().decode()
-            #gtf_text.replace('gene_name','gene_id')
-            gtf_text = gtf_text.replace('CDS','exon')
-            with open(gtf_output,'w') as o:
+            # gtf_text.replace('gene_name','gene_id')
+            gtf_text = gtf_text.replace("CDS", "exon")
+            with open(gtf_output, "w") as o:
                 o.write(gtf_text)
-            self.add_genome_data('gtf',gtf_output) 
+            self.add_genome_data("gtf", gtf_output)
         except Exception as e:
-            sys.stderr.write('Error converting gff to gtf:\n{0}\n'.format(e))
+            sys.stderr.write("Error converting gff to gtf:\n{0}\n".format(e))
             return False
 
     def get_genome_database_prefix(self):
         return None
 
     # TODO: make more robust
-    def __repr__(self): 
-        return ("Test print genome repr: {0}".format(self.genome_id))
-    
-    # TODO: make more robust
-    def __str__(self): 
-        return ("Test print genome str: {0}".format(self.genome_id))
+    def __repr__(self):
+        return "Test print genome repr: {0}".format(self.genome_id)
 
+    # TODO: make more robust
+    def __str__(self):
+        return "Test print genome str: {0}".format(self.genome_id)
 
 
 class Sample:
-
-    #Class Enums
-    valid_sample_types = ["paired","single","sra"]
+    # Class Enums
+    valid_sample_types = ["paired", "single", "sra"]
 
     sample_id = None
-    sample_type = None #paired, single, sra
+    sample_type = None  # paired, single, sra
     sample_path = None
-    reads_list = None #list (paired or single) or none (sra)
-    accession = None # TODO: maybe remove?, string (sra) or none (paired or single)
+    reads_list = None  # list (paired or single) or none (sra)
+    accession = None  # TODO: maybe remove?, string (sra) or none (paired or single)
     condition = None
     sample_data = None
     # TODO: sample_output_folder
     # TODO: think about how to store pipeline commands
     command_dict = None
-    command_status_dict = None #TODO: values "running", "finished" or an execution error
+    command_status_dict = (
+        None  # TODO: values "running", "finished" or an execution error
+    )
     # flags for different parts in the pipeline
     alignment_success = False
     alignment_check = False
@@ -191,7 +230,7 @@ class Sample:
     # Parameters:
     #   - si: sample id
     #   - st: sample type
-    #   - fp: file path 
+    #   - fp: file path
     #   - ac: accession
     #   - c: condition
     def __init__(self, si, st, rl, ac, c):
@@ -199,7 +238,11 @@ class Sample:
         self.sample_type = st
         # TODO: change sample type based on SRA single or paired
         if not self.sample_type in self.valid_sample_types:
-            print("{0} not a valid sample type: {1}".format(self.sample_type, ",".join(self.valid_sample_types)))
+            print(
+                "{0} not a valid sample type: {1}".format(
+                    self.sample_type, ",".join(self.valid_sample_types)
+                )
+            )
             return None
         self.reads_list = rl
         self.accession = ac
@@ -208,37 +251,41 @@ class Sample:
         self.command_status_dict = {}
         self.sample_data = {}
 
-    def add_command(self,key,command, status):
+    def add_command(self, key, command, status):
         if key in self.command_dict:
-            print("{0} already exists in command_dict, status {1}:\n{2}".format(key, self.command_status_dict[key], self.command_dict[key]))
+            print(
+                "{0} already exists in command_dict, status {1}:\n{2}".format(
+                    key, self.command_status_dict[key], self.command_dict[key]
+                )
+            )
         else:
             self.command_dict[key] = command
             self.command_status_dict[key] = status
 
-    def set_command_status(self,key,status):
+    def set_command_status(self, key, status):
         if key not in self.command_dict:
             print("{0} does not exist in command dict".format(key))
         else:
             self.command_status_dict[key] = status
 
-    def add_sample_data(self,key,data):
+    def add_sample_data(self, key, data):
         # TODO: check if key is valid
         self.sample_data[key] = data
 
-    def get_sample_data(self,key):
+    def get_sample_data(self, key):
         if not key in self.sample_data:
             print("{0} not in sample {1}".format(key, self.sample_id))
             return None
         else:
             return self.sample_data[key]
 
-    def check_key(self,key):
+    def check_key(self, key):
         if key in self.sample_data:
             return True
         else:
             return False
 
-    def set_path(self,path):
+    def set_path(self, path):
         self.sample_path = path
 
     def get_path(self):
@@ -272,19 +319,19 @@ class Sample:
         return self.alignment_check
 
     # TODO: make more robust
-    def __repr__(self): 
-        return ("Test print sample repr: {0}".format(self.sample_id))
-    
+    def __repr__(self):
+        return "Test print sample repr: {0}".format(self.sample_id)
+
     # TODO: make more robust
-    def __str__(self): 
-        return ("Test print sample str: {0}".format(self.sample_id))
+    def __str__(self):
+        return "Test print sample str: {0}".format(self.sample_id)
+
 
 class Condition:
-
     condition = None
     cond_path = None
     sample_list = None
-    
+
     def __init__(self, c):
         self.condition = c
         self.sample_list = []
@@ -305,26 +352,30 @@ class Condition:
         return self.condition
 
     def __str__(self):
-        return ("Test print condition str: {0}\n{1}\n".format(self.condition,self.sample_list))
+        return "Test print condition str: {0}\n{1}\n".format(
+            self.condition, self.sample_list
+        )
 
     def __repr__(self):
-        return ("Test print condition repr: {0}\n{1}\n".format(self.condition,self.sample_list))
+        return "Test print condition repr: {0}\n{1}\n".format(
+            self.condition, self.sample_list
+        )
+
 
 class Comparison:
-    
     contrast_list = None
-    
+
     def __init__(self):
         self.contrast_list = []
 
     def add_contrast(self, condition1, condition2):
-        self.contrast_list.append([condition1,condition2])
+        self.contrast_list.append([condition1, condition2])
 
     def get_contrast_list(self):
         ret_list = []
         for pair in self.contrast_list:
             ret_list.append(":".join(pair))
-        return ret_list 
+        return ret_list
 
     def check_diffexp(self):
-        return (len(self.contrast_list) > 0)
+        return len(self.contrast_list) > 0

--- a/lib/experiment.py
+++ b/lib/experiment.py
@@ -28,7 +28,9 @@ class Genome:
     genome_name = None  # TODO: incorporate into paths
     genome_type = None  # bacteria or host
     genome_dir = None
-    genome_data = None  # Dictionary that holds fasta, annotation, hisat index, etc
+    genome_data = (
+        None  # Dictionary that holds fasta, annotation, hisat index, etc
+    )
     sample_path_dict = None
 
     def __init__(self, gi, gt, session, genome_query=True):
@@ -53,7 +55,9 @@ class Genome:
                 "content-type": "application/rqlquery+x-www-form-urlencoded",
                 "Authorization": session.headers["Authorization"],
             }
-            print("genome_query:\nurl = {0}\n{1}\n".format(base + query, headers))
+            print(
+                "genome_query:\nurl = {0}\n{1}\n".format(base + query, headers)
+            )
             genome_res = bvb.getQueryDataText(base, query, headers)
             # res['response']['docs'][0]['common_name']
             response_json = json.load(io.StringIO(genome_res))
@@ -171,14 +175,21 @@ class Genome:
             self.add_genome_data("bed", bed_file)
         except Exception as e:
             sys.stderr.write(
-                "bed file generation failed for genome {0}\n".format(self.get_id())
+                "bed file generation failed for genome {0}\n".format(
+                    self.get_id()
+                )
             )
             print("error: {0}".format(e))
             return False
 
         # setup gtf file
         # TPMCalculator -g ~/Genomes/9606/GCF_000001405.39_GRCh38.p13_genomic.mod.gtf -b Test_Htseq/9606/avirulent/replicate1/SRR10307420.bam -e
-        gff_to_gtf_cmd = ["gffread", self.get_genome_data("annotation"), "-T", "-o-"]
+        gff_to_gtf_cmd = [
+            "gffread",
+            self.get_genome_data("annotation"),
+            "-T",
+            "-o-",
+        ]
         gtf_output = self.get_genome_data("annotation").replace(".gff", ".gtf")
         try:
             print(" ".join(gff_to_gtf_cmd))
@@ -213,7 +224,9 @@ class Sample:
     sample_type = None  # paired, single, sra
     sample_path = None
     reads_list = None  # list (paired or single) or none (sra)
-    accession = None  # TODO: maybe remove?, string (sra) or none (paired or single)
+    accession = (
+        None  # TODO: maybe remove?, string (sra) or none (paired or single)
+    )
     condition = None
     sample_data = None
     # TODO: sample_output_folder

--- a/lib/process.py
+++ b/lib/process.py
@@ -41,8 +41,7 @@ class DifferentialExpression:
             return self.run_cuffdiff(output_dir, sample_list)
         else:
             sys.stderr.write(
-                "Invalid recipe for differential expression: ",
-                str(self.recipe)
+                "Invalid recipe for differential expression: ", str(self.recipe)
             )
             return False
 
@@ -84,7 +83,9 @@ class DifferentialExpression:
     # TODO: don't let colons exist in the condition names on UI
     def run_deseq2(self, output_dir):
         contrast_list = self.comparisons.get_contrast_list()
-        gene_counts = self.genome.get_genome_data(f"{self.genome.get_id()}_gene_counts")
+        gene_counts = self.genome.get_genome_data(
+            f"{self.genome.get_id()}_gene_counts"
+        )
         genome_type = self.genome.get_genome_type()
         meta_file = self.genome.get_genome_data("sample_metadata_file")
 
@@ -123,7 +124,7 @@ class DifferentialExpression:
             subprocess.check_call(deseq_cmd)
             self.genome.add_genome_data(
                 "contrast_file_list", contrast_file_list
-                )
+            )
             # invoke volcano plots script
             # rnaseq_volcano_plots.R <output_prefix> <deseq2_file1> <contrast_name1> <deseq2_file2> <contrast_name2>...
             print("Running Command:\n{0}".format(" ".join(ev_cmd)))
@@ -285,7 +286,9 @@ class GenomeData:
                     "superclass_figure", superclass_figure + ".png"
                 )
         except Exception as e:
-            sys.stderr.write("Error creating superclass violin plots:\n{0}\n".format(e))
+            sys.stderr.write(
+                "Error creating superclass violin plots:\n{0}\n".format(e)
+            )
 
         try:
             pathway_figure = os.path.join(
@@ -304,9 +307,13 @@ class GenomeData:
                 # TODO: ENABLE
                 subprocess.check_call(pathway_cmd)
                 # self.genome.add_genome_data('pathway_figure',pathway_figure+'.svg')
-                self.genome.add_genome_data("pathway_figure", pathway_figure + ".png")
+                self.genome.add_genome_data(
+                    "pathway_figure", pathway_figure + ".png"
+                )
         except Exception as e:
-            sys.stderr.write("Error creating pathway violin plots:\n{0}\n".format(e))
+            sys.stderr.write(
+                "Error creating pathway violin plots:\n{0}\n".format(e)
+            )
 
     def create_fpkm_figures(self, output_dir):
         superclass_mapping = self.genome.get_genome_data("superclass_mapping")
@@ -314,7 +321,8 @@ class GenomeData:
         genome_counts = self.genome.get_genome_data("fpkm")
         if genome_counts is None:
             sys.stderr.write(
-                "No fpkm's matrix in genome data: ", "exiting create_fpkm_figures\n"
+                "No fpkm's matrix in genome data: ",
+                "exiting create_fpkm_figures\n",
             )
             return False
         metadata = self.genome.get_genome_data("sample_metadata_file")
@@ -339,7 +347,9 @@ class GenomeData:
                     "superclass_figure", superclass_figure + ".png"
                 )
         except Exception as e:
-            sys.stderr.write("Error creating superclass violin plots:\n{0}\n".format(e))
+            sys.stderr.write(
+                "Error creating superclass violin plots:\n{0}\n".format(e)
+            )
         try:
             pathway_figure = os.path.join(
                 self.genome.get_genome_data("report_img_path"),
@@ -357,9 +367,13 @@ class GenomeData:
                 # TODO: ENABLE
                 subprocess.check_call(pathway_cmd)
                 # self.genome.add_genome_data('pathway_figure',pathway_figure+'.svg')
-                self.genome.add_genome_data("pathway_figure", pathway_figure + ".png")
+                self.genome.add_genome_data(
+                    "pathway_figure", pathway_figure + ".png"
+                )
         except Exception as e:
-            sys.stderr.write("Error creating pathway violin plots:\n{0}\n".format(e))
+            sys.stderr.write(
+                "Error creating pathway violin plots:\n{0}\n".format(e)
+            )
 
     def run_pathway(self, output_dir, session):
         # pathway_df = getPathwayDataFrame([self.genome.get_id()], session)
@@ -372,7 +386,7 @@ class GenomeData:
         }
         pathway_df = pd.DataFrame(
             json.loads(getQueryDataText(base, query, headers))
-            )
+        )
         if pathway_df is not None:
             mapping_table = pathway_df[["patric_id", "pathway_class"]]
             mapping_output = os.path.join(output_dir, "pathway_mapping.tsv")
@@ -462,9 +476,7 @@ class Quantify:
             os.mkdir("TPMCalculator")
         os.chdir("TPMCalculator")
         with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as pool:
-            future_returns = list(
-                pool.map(self.run_tpmcalc_job, tpm_args_list)
-                )
+            future_returns = list(pool.map(self.run_tpmcalc_job, tpm_args_list))
         os.chdir("../")
         for f in future_returns:
             if f != 0:
@@ -493,9 +505,8 @@ class Quantify:
                     )
                 )
             sample.add_sample_data(
-                f"{self.genome.get_id()}_tpm_out",
-                output_file
-                )
+                f"{self.genome.get_id()}_tpm_out", output_file
+            )
         except Exception as e:
             sys.stderr.write("Error running concurrent tpm job:{0}".format(e))
             sample.set_command_status("tpm" + "_" + self.genome.get_id(), e)
@@ -527,9 +538,15 @@ class Quantify:
             ]
             quant_cmd_list.append(quant_cmd)
             sample_dir = self.genome.get_sample_path(sample.get_id())
-            sample_output_file = os.path.join(sample_dir, sample.get_id() + ".counts")
-            sample_err_file = os.path.join(sample_dir, sample.get_id() + ".htseq_err")
-            sample_details_list.append([sample_output_file, sample, sample_err_file])
+            sample_output_file = os.path.join(
+                sample_dir, sample.get_id() + ".counts"
+            )
+            sample_err_file = os.path.join(
+                sample_dir, sample.get_id() + ".htseq_err"
+            )
+            sample_details_list.append(
+                [sample_output_file, sample, sample_err_file]
+            )
         quant_args_list = list(zip(quant_cmd_list, sample_details_list))
         future_returns = []
         # redirect stderr
@@ -554,8 +571,12 @@ class Quantify:
             # TODO: ENABLE
             with open(output_file, "w") as o, open(err_file, "w") as e:
                 subprocess.check_call(cmd, stdout=o, stderr=e)
-            sample.set_command_status("htseq" + "_" + self.genome.get_id(), "finished")
-            sample.add_sample_data(self.genome.get_id() + "_gene_counts", output_file)
+            sample.set_command_status(
+                "htseq" + "_" + self.genome.get_id(), "finished"
+            )
+            sample.add_sample_data(
+                self.genome.get_id() + "_gene_counts", output_file
+            )
         except Exception as e:
             sys.stderr.write("Error running concurrent htseq job:{0}".format(e))
             sample.set_command_status("htseq" + "_" + self.genome.get_id(), e)
@@ -564,18 +585,28 @@ class Quantify:
 
     def create_genome_counts_table(self, output_dir, sample_list):
         if self.recipe == "HTSeq-DESeq":
-            return self.create_genome_counts_table_htseq(output_dir, sample_list)
+            return self.create_genome_counts_table_htseq(
+                output_dir, sample_list
+            )
         elif self.recipe == "Host":
-            return self.create_genome_counts_table_stringtie(output_dir, sample_list)
+            return self.create_genome_counts_table_stringtie(
+                output_dir, sample_list
+            )
         elif self.recipe == "cufflinks":
-            return self.create_genome_counts_table_cufflinks(output_dir, sample_list, 8)
+            return self.create_genome_counts_table_cufflinks(
+                output_dir, sample_list, 8
+            )
         else:
             sys.stderr.write(
-                "No counts table method found for recipe {0}\n".format(self.recipe)
+                "No counts table method found for recipe {0}\n".format(
+                    self.recipe
+                )
             )
             return None
 
-    def create_genome_counts_table_cufflinks(self, output_dir, sample_list, threads):
+    def create_genome_counts_table_cufflinks(
+        self, output_dir, sample_list, threads
+    ):
         gtf_list = []
         for sample in sample_list:
             gtf_list.append(sample.get_sample_data("cuff_gtf"))
@@ -669,7 +700,8 @@ class Quantify:
                 self.genome.get_id() + "_gene_counts", gene_matrix_file
             )
             self.genome.add_genome_data(
-                self.genome.get_id() + "_transcript_counts", transcript_matrix_file
+                self.genome.get_id() + "_transcript_counts",
+                transcript_matrix_file,
             )
         except Exception as e:
             sys.stderr.write(
@@ -696,7 +728,8 @@ class Quantify:
         output_file = os.path.join(output_dir, "gene_counts_matrix.tsv")
         genome_df.to_csv(output_file, sep="\t")
         self.genome.add_genome_data(
-            self.genome.get_id() + "_gene_counts", output_file)
+            self.genome.get_id() + "_gene_counts", output_file
+        )
         return output_file
 
     def create_genome_quant_table(self, output_dir, sample_list):
@@ -750,20 +783,20 @@ class Quantify:
         # create fpkm matrix
         try:
             fpkm_file = os.path.join(
-                output_dir,
-                "cuffnorm_output/genes.fpkm_table"
-                )
+                output_dir, "cuffnorm_output/genes.fpkm_table"
+            )
             if not os.path.exists(fpkm_file):
                 sys.stderr.write(
                     f"Error running cuffnorm: {fpkm_file} does not exist\n"
                 )
                 return -1
             attr_file = os.path.join(
-                output_dir,
-                "cuffnorm_output/genes.attr_table"
-                )
+                output_dir, "cuffnorm_output/genes.attr_table"
+            )
             if not os.path.exists(attr_file):
-                sys.stderr.write(f"Error running cuffnorm: {attr_file} oes not exist\n")
+                sys.stderr.write(
+                    f"Error running cuffnorm: {attr_file} oes not exist\n"
+                )
                 return -1
             # print(f'fpkm_file = {fpkm_file}')
             attr_dict = {}
@@ -808,20 +841,15 @@ class Quantify:
             )
             sample_df = sample_df[["Gene_Id", "TPM"]]
             sample_df.rename(
-                columns={
-                    "Gene_Id": "Gene_Id",
-                    "TPM": sample.get_id()
-                    },
-                inplace=True
+                columns={"Gene_Id": "Gene_Id", "TPM": sample.get_id()},
+                inplace=True,
             )
             if genome_df is None:
                 genome_df = sample_df
             else:
                 genome_df = genome_df.merge(
-                    sample_df,
-                    how="outer",
-                    on="Gene_Id"
-                    )
+                    sample_df, how="outer", on="Gene_Id"
+                )
         genome_df = genome_df.fillna(0)
         genome_df.set_index("Gene_Id", inplace=True)
         output_file = os.path.join(output_dir, "tpm_counts_matrix.tsv")
@@ -834,19 +862,21 @@ class Quantify:
             sample_df = pd.read_csv(
                 sample.get_sample_data(
                     f"{self.genome.get_id()}_merged_gene_counts"
-                    ),
+                ),
                 sep="\t",
             )
             sample_df = sample_df.loc[sample_df["Gene ID"] != "."]
             sample_df = sample_df[["Gene ID", "TPM"]]
             sample_df.rename(
                 columns={"Gene ID": "Gene_Id", "TPM": sample.get_id()},
-                inplace=True
+                inplace=True,
             )
             if genome_df is None:
                 genome_df = sample_df
             else:
-                genome_df = genome_df.merge(sample_df, how="outer", on="Gene_Id")
+                genome_df = genome_df.merge(
+                    sample_df, how="outer", on="Gene_Id"
+                )
             genome_df = genome_df.fillna(0)
             genome_df.set_index("Gene_Id", inplace=True)
             output_file = os.path.join(output_dir, "tpm_counts_matrix.tsv")
@@ -895,10 +925,12 @@ class Quantify:
                         self.genome.get_id() + "_transcripts", gtf_output
                     )
                 except Exception as e:
-                    sys.stderr.write("Error running stringtie:\n{0}\n".format(e))
+                    sys.stderr.write(
+                        "Error running stringtie:\n{0}\n".format(e)
+                    )
                     sample.set_command_status(
                         f"stringtie_{self.genome.get_id()}", e
-                        )
+                    )
                     return -1
             else:
                 sys.stderr.write(
@@ -919,7 +951,9 @@ class Quantify:
                 print("Running command:\n{0}\n".format(" ".join(merge_cmd)))
                 subprocess.check_call(merge_cmd)
             except Exception as e:
-                sys.stderr.write("ERROR running stringtie-merge:\n{0}".format(e))
+                sys.stderr.write(
+                    "ERROR running stringtie-merge:\n{0}".format(e)
+                )
                 return -1
         self.genome.add_genome_data("merged_gtf", merge_file)
 
@@ -947,7 +981,8 @@ class Quantify:
             if not os.path.exists(gtf_output) or True:
                 sample.add_command(
                     f"stringtie_merged_{self.genome.get_id()}",
-                    quant_cmd, "running"
+                    quant_cmd,
+                    "running",
                 )
                 print("Running command:\n{0}\n".format(" ".join(quant_cmd)))
                 try:
@@ -956,17 +991,16 @@ class Quantify:
                         "stringtie_merged_" + self.genome.get_id(), "finished"
                     )
                     sample.add_sample_data(
-                        self.genome.get_id() + "_merged_transcripts",
-                        gtf_output
+                        self.genome.get_id() + "_merged_transcripts", gtf_output
                     )
                     sample.add_sample_data(
                         self.genome.get_id() + "_merged_gene_counts",
-                        gene_output
+                        gene_output,
                     )
                 except Exception as e:
                     sys.stderr.write(
                         "Error running stringtie-merged:\n{0}\n".format(e)
-                        )
+                    )
                     sample.set_command_status(
                         "stringtie_merged_" + self.genome.get_id(), e
                     )
@@ -1005,7 +1039,9 @@ class Quantify:
             bam_to_use = None
 
             try:
-                tmpfd, bam_tmp = tempfile.mkstemp(prefix="CUFFL.", dir="/dev/shm")
+                tmpfd, bam_tmp = tempfile.mkstemp(
+                    prefix="CUFFL.", dir="/dev/shm"
+                )
                 os.close(tmpfd)
                 shutil.copy(sample_bam, bam_tmp)
                 print("Copy succeeded to %s" % (bam_tmp))
@@ -1080,7 +1116,11 @@ class Alignment:
         reads_list = sample.get_reads_as_list()
         sam_file = os.path.join(sample_dir, sample.get_id() + ".sam")
         if self.genome.get_genome_type() == "bacteria":
-            align_cmd = ["bowtie2", "-x", self.genome.get_genome_data("bowtie_prefix")]
+            align_cmd = [
+                "bowtie2",
+                "-x",
+                self.genome.get_genome_data("bowtie_prefix"),
+            ]
         else:
             align_cmd = [
                 "hisat2",
@@ -1096,7 +1136,9 @@ class Alignment:
         elif sample.sample_type == "single":
             align_cmd += ["-U", reads_list[0]]
         align_cmd += ["-S", sam_file, "-p", str(threads)]
-        sample.add_command(f"align_{self.genome.get_id()}", align_cmd, "running")
+        sample.add_command(
+            f"align_{self.genome.get_id()}", align_cmd, "running"
+        )
         align_output_file = sam_file.replace(".sam", ".align_stdout")
         print("Running command:\n{0}".format(" ".join(align_cmd)))
         try:
@@ -1112,7 +1154,9 @@ class Alignment:
                 self.genome.get_id() + "_align_stats", align_output_file
             )
             sample.set_alignment_status(True)
-            sample.set_command_status("align_" + self.genome.get_id(), "finished")
+            sample.set_command_status(
+                "align_" + self.genome.get_id(), "finished"
+            )
         except Exception as e:
             sys.stderr.write(
                 "Sample-alignment encountered an error in Sample ",
@@ -1181,7 +1225,9 @@ class Alignment:
         sample_bam = sample.get_sample_data("bam")
         # samtools stats
         stats_cmd = ["samtools", "stats", "--threads", str(threads), sample_bam]
-        stats_output = os.path.join(sample_dir, sample.get_id() + ".samtools_stats")
+        stats_output = os.path.join(
+            sample_dir, sample.get_id() + ".samtools_stats"
+        )
         sample.add_command(
             "samtools_stats_" + self.genome.get_id(), stats_cmd, "running"
         )
@@ -1199,19 +1245,25 @@ class Alignment:
                     sample.get_id()
                 )
             )
-            sample.set_command_status("samtools_stats_" + self.genome.get_id(), e)
+            sample.set_command_status(
+                "samtools_stats_" + self.genome.get_id(), e
+            )
 
         avg_len = self.get_average_read_length_per_file(stats_output)
         sample.add_sample_data("avg_read_length", avg_len)
 
         # samstat
         samstat_cmd = ["samstat", sample_bam]
-        sample.add_command("samstat_" + self.genome.get_id(), samstat_cmd, "running")
+        sample.add_command(
+            "samstat_" + self.genome.get_id(), samstat_cmd, "running"
+        )
         try:
             print("Running command:\n{0}".format(" ".join(samstat_cmd)))
             # TODO: ENABLE
             subprocess.check_call(samstat_cmd)
-            sample.set_command_status("samstat_" + self.genome.get_id(), "finished")
+            sample.set_command_status(
+                "samstat_" + self.genome.get_id(), "finished"
+            )
         except Exception as e:
             sys.stderr.write(
                 "Samstat encountered an error in Sample {0}:\ncheck error log file".format(
@@ -1247,7 +1299,14 @@ class Alignment:
             sample_file.append("fq")
             sample_file = ".".join(sample_file)
             sampled_reads_list.append(sample_file)
-            sample_cmd = ["seqtk", "sample", "-s", "42", r, str(self.sampled_reads)]
+            sample_cmd = [
+                "seqtk",
+                "sample",
+                "-s",
+                "42",
+                r,
+                str(self.sampled_reads),
+            ]
             sample.add_command("sample" + str(readNum), sample_cmd, "running")
             print("Running command:\n{0}".format(" ".join(sample_cmd)))
             try:
@@ -1363,7 +1422,9 @@ class Alignment:
             # TODO: ENABLE
             subprocess.check_call(sam_to_bam_cmd, shell=True)
         except Exception as e:
-            sys.stderr.write("Error in converting sam to bam file:\n{0}\n".format(e))
+            sys.stderr.write(
+                "Error in converting sam to bam file:\n{0}\n".format(e)
+            )
             return None
         index_cmd = "samtools index " + bam_file
         try:
@@ -1417,7 +1478,9 @@ class DiffExpImport:
             print("Skipping contrast file export; contrast_file_list is None")
         else:
             for contrast_file in contrast_file_list:
-                contrast_name = os.path.basename(contrast_file).replace(".tsv", "")
+                contrast_name = os.path.basename(contrast_file).replace(
+                    ".tsv", ""
+                )
                 contrast_list.append(contrast_name)
                 gene_count_dict[contrast_name] = {}
                 with open(contrast_file, "r") as cf:
@@ -1499,7 +1562,7 @@ class DiffExpImport:
             except subprocess.CalledProcessError:
                 sys.stderr.write(
                     "Running differential expression import failed.\n"
-                    )
+                )
                 # subprocess.call(["rm","-rf",experiment_path])
                 return
             diffexp_obj_file = os.path.join(
@@ -1511,7 +1574,7 @@ class DiffExpImport:
         else:
             sys.stderr.write(
                 "GMX file does not exist, ",
-                "exiting differential expression import"
+                "exiting differential expression import",
             )
             return False
 
@@ -1627,9 +1690,11 @@ class Preprocess:
         trimmed_reads = []
         trim_cmd = [
             "trim_galore",
-            "--output_dir", sample_dir,
-            "--cores", str(threads)
-            ]
+            "--output_dir",
+            sample_dir,
+            "--cores",
+            str(threads),
+        ]
         if sample.get_type() == "paired":
             # trimmed_reads.append(os.path.join(sample_dir,os.path.basename(reads[0]).split(".")[0]+"_val_1.fq.gz"))
             # trimmed_reads.append(os.path.join(sample_dir,os.path.basename(reads[1]).split(".")[0]+"_val_2.fq.gz"))

--- a/lib/process.py
+++ b/lib/process.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-#library modules
+# library modules
 import sys, os, subprocess, shutil
 import concurrent.futures
 import glob, json
@@ -10,10 +10,10 @@ from math import log
 import pandas as pd
 import numpy as np
 
-from bvbrc_api import getQueryDataText,getSubsystemsDataFrame,getPathwayDataFrame
+from bvbrc_api import getQueryDataText, getSubsystemsDataFrame, getPathwayDataFrame
+
 
 class DifferentialExpression:
-
     comparisons = None
     genome = None
     recipe = None
@@ -22,7 +22,7 @@ class DifferentialExpression:
         print("Creating DifferentialExpression manager")
         self.comparisons = c
 
-    # used to set correct counts matrix delimiter and 
+    # used to set correct counts matrix delimiter and
     # to run gene+transcript diffexp if host (just gene for bacteria)
     def set_genome(self, g):
         self.genome = g
@@ -30,174 +30,208 @@ class DifferentialExpression:
     def set_recipe(self, r):
         self.recipe = r
 
-    def run_differential_expression(self,output_dir,sample_list):
-        if self.recipe == 'HTSeq-DESeq' or self.recipe == 'Host':
+    def run_differential_expression(self, output_dir, sample_list):
+        if self.recipe == "HTSeq-DESeq" or self.recipe == "Host":
             return self.run_deseq2(output_dir)
-        elif self.recipe == 'cufflinks':
-            return self.run_cuffdiff(output_dir,sample_list)
+        elif self.recipe == "cufflinks":
+            return self.run_cuffdiff(output_dir, sample_list)
         else:
-            sys.stderr.write('Invalid recipe for differential expression: {0}\n'.format(self.recipe))
+            sys.stderr.write(
+                "Invalid recipe for differential expression: {0}\n".format(self.recipe)
+            )
             return False
 
-    def run_cuffdiff(self,output_dir,sample_list):
+    def run_cuffdiff(self, output_dir, sample_list):
         threads = 8
-        merged_gtf = self.genome.get_genome_data('merge_gtf')
-        cuffdiff_cmd = ['cuffdiff','-p',str(threads),merged_gtf]
+        merged_gtf = self.genome.get_genome_data("merge_gtf")
+        cuffdiff_cmd = ["cuffdiff", "-p", str(threads), merged_gtf]
         # TODO: replace with contrast or condition class?
         sam_dict = {}
         for sample in sample_list:
-            sample_condition = sample.get_condition() 
+            sample_condition = sample.get_condition()
             if sample_condition not in sam_dict:
                 sam_dict[sample_condition] = []
-            sam_dict[sample_condition].append(sample.get_sample_data('bam'))
+            sam_dict[sample_condition].append(sample.get_sample_data("bam"))
         for sample_condition in sam_dict:
-            cuffdiff_cmd += [','.join(sam_dict[sample_condition])]
-        print('Running Command:\n{0}'.format(' '.join(cuffdiff_cmd)))
+            cuffdiff_cmd += [",".join(sam_dict[sample_condition])]
+        print("Running Command:\n{0}".format(" ".join(cuffdiff_cmd)))
         try:
             subprocess.check_call(cuffdiff_cmd)
-            gmx_file = os.path.join(output_dir,'gene_exp.gmx')
-            diff_file = os.path.join(output_dir,'gene_exp.diff')
-            self.create_gmx_file([diff_file],gmx_file) 
-            self.genome.add_genome_data('gmx',gmx_file)
+            gmx_file = os.path.join(output_dir, "gene_exp.gmx")
+            diff_file = os.path.join(output_dir, "gene_exp.diff")
+            self.create_gmx_file([diff_file], gmx_file)
+            self.genome.add_genome_data("gmx", gmx_file)
         except Exception as e:
-            sys.stderr.write('Error running cuffdiff:\n{0}'.format(e))
+            sys.stderr.write("Error running cuffdiff:\n{0}".format(e))
             return -1
 
     def create_metadata_file(self, sample_list, output_dir):
-        meta_file = os.path.join(output_dir,'sample_metadata.tsv')
-        output_text_list = ['Sample\tCondition']
+        meta_file = os.path.join(output_dir, "sample_metadata.tsv")
+        output_text_list = ["Sample\tCondition"]
         for sample in sample_list:
-            text = sample.get_id() + '\t' + sample.get_condition()
+            text = sample.get_id() + "\t" + sample.get_condition()
             output_text_list.append(text)
-        output_text = '\n'.join(output_text_list) + '\n'
-        with open(meta_file,'w') as o:
+        output_text = "\n".join(output_text_list) + "\n"
+        with open(meta_file, "w") as o:
             o.write(output_text)
         return meta_file
 
     # TODO: don't let colons exist in the condition names on UI
-    def run_deseq2(self,output_dir): 
-        contrast_list = self.comparisons.get_contrast_list() 
-        gene_counts = self.genome.get_genome_data(self.genome.get_id()+"_gene_counts")
+    def run_deseq2(self, output_dir):
+        contrast_list = self.comparisons.get_contrast_list()
+        gene_counts = self.genome.get_genome_data(self.genome.get_id() + "_gene_counts")
         genome_type = self.genome.get_genome_type()
-        meta_file = self.genome.get_genome_data('sample_metadata_file')
+        meta_file = self.genome.get_genome_data("sample_metadata_file")
 
         if output_dir[-1] != "/":
             output_dir = output_dir + "/"
 
-        deseq_cmd = ['run_deseq2_bvbrc',gene_counts,meta_file,output_dir,self.genome.get_genome_data('report_img_path'),genome_type]
-        #deseq_cmd = ['run_deseq2_bvbrc',gene_counts,meta_file,output_dir,self.genome.get_genome_data('report_img_path'),genome_type]
-        #vp_figure = os.path.join(self.genome.get_genome_data('report_img_path'),output_prefix+'volcano_plot.svg')
-        vp_figure = os.path.join(self.genome.get_genome_data('report_img_path'),'volcano_plot.png')
-        ev_cmd = ['rnaseq_volcano_plots',self.genome.get_genome_data('report_img_path')]
+        deseq_cmd = [
+            "run_deseq2_bvbrc",
+            gene_counts,
+            meta_file,
+            output_dir,
+            self.genome.get_genome_data("report_img_path"),
+            genome_type,
+        ]
+        # deseq_cmd = ['run_deseq2_bvbrc',gene_counts,meta_file,output_dir,self.genome.get_genome_data('report_img_path'),genome_type]
+        # vp_figure = os.path.join(self.genome.get_genome_data('report_img_path'),output_prefix+'volcano_plot.svg')
+        vp_figure = os.path.join(
+            self.genome.get_genome_data("report_img_path"), "volcano_plot.png"
+        )
+        ev_cmd = [
+            "rnaseq_volcano_plots",
+            self.genome.get_genome_data("report_img_path"),
+        ]
         contrast_file_list = []
         for contrast in contrast_list:
             deseq_cmd = deseq_cmd + [contrast]
-            cond1 = contrast.split(':')[0]
-            cond2 = contrast.split(':')[1]
-            diffexp_file = os.path.join(output_dir,cond1 + '_vs_' + cond2 + '.deseq2.tsv') 
-            ev_cmd = ev_cmd + [diffexp_file,contrast.replace(':','_vs_')]
+            cond1 = contrast.split(":")[0]
+            cond2 = contrast.split(":")[1]
+            diffexp_file = os.path.join(
+                output_dir, cond1 + "_vs_" + cond2 + ".deseq2.tsv"
+            )
+            ev_cmd = ev_cmd + [diffexp_file, contrast.replace(":", "_vs_")]
             contrast_file_list.append(diffexp_file)
         try:
-            print('Running Command:\n{0}'.format(' '.join(deseq_cmd)))
+            print("Running Command:\n{0}".format(" ".join(deseq_cmd)))
             subprocess.check_call(deseq_cmd)
-            self.genome.add_genome_data('contrast_file_list',contrast_file_list)
+            self.genome.add_genome_data("contrast_file_list", contrast_file_list)
             # invoke volcano plots script
             # rnaseq_volcano_plots.R <output_prefix> <deseq2_file1> <contrast_name1> <deseq2_file2> <contrast_name2>...
-            print('Running Command:\n{0}'.format(' '.join(ev_cmd)))
+            print("Running Command:\n{0}".format(" ".join(ev_cmd)))
             subprocess.check_call(ev_cmd)
-            self.genome.add_genome_data('rnaseq_volcano_plots',vp_figure)
+            self.genome.add_genome_data("rnaseq_volcano_plots", vp_figure)
         except Exception as e:
-            sys.stderr.write('Error running run_deseq2:\n{0}'.format(e))
+            sys.stderr.write("Error running run_deseq2:\n{0}".format(e))
             return -1
-         
-        # TODO: run transcript counts
-        if self.genome.get_genome_type() == 'host':
-            print('implement')
-            return
-            transcript_counts = self.genome.get_genome_data(self.genome.get_id()+"_transcript_counts")
 
-        
+        # TODO: run transcript counts
+        if self.genome.get_genome_type() == "host":
+            print("implement")
+            return
+            transcript_counts = self.genome.get_genome_data(
+                self.genome.get_id() + "_transcript_counts"
+            )
 
     def create_gmx_file(self, init_args, output_file):
-        output_handle=open(output_file, 'w')
-        if(len(init_args)<1):
-            print ("Usage cuffdiff_to_genematrix.py  <cuffdiff files>")
+        output_handle = open(output_file, "w")
+        if len(init_args) < 1:
+            print("Usage cuffdiff_to_genematrix.py  <cuffdiff files>")
             exit(0)
-        master_list_genes=set()
-        master_list_comparisons=set()
-        log_lookup={}
+        master_list_genes = set()
+        master_list_comparisons = set()
+        log_lookup = {}
         for input_file in init_args:
-            input_handle=open(input_file, 'r')
-            lines=input_handle.readlines()
+            input_handle = open(input_file, "r")
+            lines = input_handle.readlines()
             for line in lines[1:]:
-                parts=line.strip().split('\t')
-                status='NOT OK'
-                if len(parts)==14:
+                parts = line.strip().split("\t")
+                status = "NOT OK"
+                if len(parts) == 14:
                     try:
-                        #test_id gene_id gene    locus   sample_1        sample_2        status  value_1 value_2 log2(fold_change)       test_stat       p_value q_value significant
-                        (gene_col, sample1, sample2, status, value1, value2, log_change) = (parts[2], parts[4], parts[5], parts[6], float(parts[7]), float(parts[8]), float(parts[9]))
+                        # test_id gene_id gene    locus   sample_1        sample_2        status  value_1 value_2 log2(fold_change)       test_stat       p_value q_value significant
+                        (
+                            gene_col,
+                            sample1,
+                            sample2,
+                            status,
+                            value1,
+                            value2,
+                            log_change,
+                        ) = (
+                            parts[2],
+                            parts[4],
+                            parts[5],
+                            parts[6],
+                            float(parts[7]),
+                            float(parts[8]),
+                            float(parts[9]),
+                        )
                     except ValueError:
-                        sys.stderr.write('One of the input files does not match the formatting of a CuffDiff gene differential expression testing file\n')
+                        sys.stderr.write(
+                            "One of the input files does not match the formatting of a CuffDiff gene differential expression testing file\n"
+                        )
                         sys.exit()
                 else:
-                    sys.stderr.write('One of the input files does not match the formatting of a CuffDiff gene differential expression testing file\n')
+                    sys.stderr.write(
+                        "One of the input files does not match the formatting of a CuffDiff gene differential expression testing file\n"
+                    )
                     sys.exit()
-                if status != 'OK':
+                if status != "OK":
                     continue
                 gene_ids = []
-                if ',' in gene_col:
-                    gene_ids=gene_col.split(',')
+                if "," in gene_col:
+                    gene_ids = gene_col.split(",")
                 else:
-                    gene_ids=[gene_col]
-                changed=False
+                    gene_ids = [gene_col]
+                changed = False
                 if value1 == 0:
-                    value1=0.01
-                    changed=True
+                    value1 = 0.01
+                    changed = True
                 if value2 == 0:
-                    value2= 0.01
-                    changed=True
+                    value2 = 0.01
+                    changed = True
                 if changed:
-                    log_change= log(value2/value1)/log(2)
-                #pandas would be better for this
+                    log_change = log(value2 / value1) / log(2)
+                # pandas would be better for this
                 for gene_id in gene_ids:
                     master_list_genes.add(gene_id)
-                    comp_id=sample1+' vs '+sample2
+                    comp_id = sample1 + " vs " + sample2
                     master_list_comparisons.add(comp_id)
                     if comp_id not in log_lookup:
-                        log_lookup[comp_id]={}
-                    log_lookup[comp_id][gene_id]=log_change 
+                        log_lookup[comp_id] = {}
+                    log_lookup[comp_id][gene_id] = log_change
             input_handle.close()
-        comparisons=list(master_list_comparisons)
+        comparisons = list(master_list_comparisons)
         comparisons.sort()
-        headers=['Gene ID']+comparisons
-        genes=list(master_list_genes)
+        headers = ["Gene ID"] + comparisons
+        genes = list(master_list_genes)
         genes.sort()
-        output_handle.write('\t'.join(headers)+"\n")
+        output_handle.write("\t".join(headers) + "\n")
         for g in genes:
-            value_list=[]
+            value_list = []
             for c in comparisons:
                 try:
                     current_val = str(log_lookup[c][g])
                 except:
-                    current_val='NaN'
+                    current_val = "NaN"
                 value_list.append(current_val)
-            output_handle.write('\t'.join([g]+value_list)+"\n")
+            output_handle.write("\t".join([g] + value_list) + "\n")
         output_handle.close()
 
 
-
 class GenomeData:
-
     genome = None
     recipe = None
 
     def __init__(self):
         print("Creating GenomeData manager")
-    
-    def set_genome(self,g):
+
+    def set_genome(self, g):
         self.genome = g
 
-    def set_recipe(self,r):
+    def set_recipe(self, r):
         self.recipe = r
 
     def run_queries(self, output_dir, session):
@@ -205,519 +239,722 @@ class GenomeData:
         self.run_pathway(output_dir, session)
 
     def create_system_figures(self, output_dir):
-        if self.recipe == 'HTSeq-DESeq':
+        if self.recipe == "HTSeq-DESeq":
             self.create_tpm_figures(output_dir)
-        elif self.recipe == 'cufflinks':
+        elif self.recipe == "cufflinks":
             self.create_fpkm_figures(output_dir)
         else:
-            sys.stderr.write('Invalid recipe: exiting create system figures\n')
+            sys.stderr.write("Invalid recipe: exiting create system figures\n")
             return -1
 
     def create_tpm_figures(self, output_dir):
-        superclass_mapping = self.genome.get_genome_data('superclass_mapping')
-        pathway_mapping = self.genome.get_genome_data('pathway_mapping')
+        superclass_mapping = self.genome.get_genome_data("superclass_mapping")
+        pathway_mapping = self.genome.get_genome_data("pathway_mapping")
         genome_counts = self.genome.get_genome_data("tpm")
         if genome_counts is None:
-            sys.stderr.write('No tpm\'s matrix in genome data: exiting create_tpm_figures\n')
+            sys.stderr.write(
+                "No tpm's matrix in genome data: exiting create_tpm_figures\n"
+            )
             return False
-        metadata = self.genome.get_genome_data('sample_metadata_file')
+        metadata = self.genome.get_genome_data("sample_metadata_file")
 
         try:
-            superclass_figure = os.path.join(self.genome.get_genome_data('report_img_path'),"Superclass_Distribution")
-            superclass_cmd = ["rnaseq_grid_violin_plots",superclass_mapping,genome_counts,metadata,superclass_figure]
+            superclass_figure = os.path.join(
+                self.genome.get_genome_data("report_img_path"),
+                "Superclass_Distribution",
+            )
+            superclass_cmd = [
+                "rnaseq_grid_violin_plots",
+                superclass_mapping,
+                genome_counts,
+                metadata,
+                superclass_figure,
+            ]
             if os.path.exists(superclass_mapping):
-                print('Running command:\n{0}'.format(' '.join(superclass_cmd)))
+                print("Running command:\n{0}".format(" ".join(superclass_cmd)))
                 # TODO: ENABLE
-                subprocess.check_call(superclass_cmd) 
-                #self.genome.add_genome_data('superclass_figure',superclass_figure+'.svg')
-                self.genome.add_genome_data('superclass_figure',superclass_figure+'.png')
+                subprocess.check_call(superclass_cmd)
+                # self.genome.add_genome_data('superclass_figure',superclass_figure+'.svg')
+                self.genome.add_genome_data(
+                    "superclass_figure", superclass_figure + ".png"
+                )
         except Exception as e:
-            sys.stderr.write('Error creating superclass violin plots:\n{0}\n'.format(e))
+            sys.stderr.write("Error creating superclass violin plots:\n{0}\n".format(e))
 
         try:
-            pathway_figure = os.path.join(self.genome.get_genome_data('report_img_path'),"PathwayClass_Distribution")
-            pathway_cmd = ["rnaseq_grid_violin_plots",pathway_mapping,genome_counts,metadata,pathway_figure]
+            pathway_figure = os.path.join(
+                self.genome.get_genome_data("report_img_path"),
+                "PathwayClass_Distribution",
+            )
+            pathway_cmd = [
+                "rnaseq_grid_violin_plots",
+                pathway_mapping,
+                genome_counts,
+                metadata,
+                pathway_figure,
+            ]
             if os.path.exists(pathway_mapping):
-                print('Running command:\n{0}'.format(' '.join(pathway_cmd)))
+                print("Running command:\n{0}".format(" ".join(pathway_cmd)))
                 # TODO: ENABLE
-                subprocess.check_call(pathway_cmd) 
-                #self.genome.add_genome_data('pathway_figure',pathway_figure+'.svg')
-                self.genome.add_genome_data('pathway_figure',pathway_figure+'.png')
+                subprocess.check_call(pathway_cmd)
+                # self.genome.add_genome_data('pathway_figure',pathway_figure+'.svg')
+                self.genome.add_genome_data("pathway_figure", pathway_figure + ".png")
         except Exception as e:
-            sys.stderr.write('Error creating pathway violin plots:\n{0}\n'.format(e))
+            sys.stderr.write("Error creating pathway violin plots:\n{0}\n".format(e))
 
     def create_fpkm_figures(self, output_dir):
-        superclass_mapping = self.genome.get_genome_data('superclass_mapping')
-        pathway_mapping = self.genome.get_genome_data('pathway_mapping')
+        superclass_mapping = self.genome.get_genome_data("superclass_mapping")
+        pathway_mapping = self.genome.get_genome_data("pathway_mapping")
         genome_counts = self.genome.get_genome_data("fpkm")
         if genome_counts is None:
-            sys.stderr.write('No fpkm\'s matrix in genome data: exiting create_fpkm_figures\n')
+            sys.stderr.write(
+                "No fpkm's matrix in genome data: exiting create_fpkm_figures\n"
+            )
             return False
-        metadata = self.genome.get_genome_data('sample_metadata_file')
+        metadata = self.genome.get_genome_data("sample_metadata_file")
         try:
-            superclass_figure = os.path.join(self.genome.get_genome_data('report_img_path'),"Superclass_Distribution")
-            superclass_cmd = ["rnaseq_grid_violin_plots_cufflinks",superclass_mapping,genome_counts,metadata,superclass_figure]
+            superclass_figure = os.path.join(
+                self.genome.get_genome_data("report_img_path"),
+                "Superclass_Distribution",
+            )
+            superclass_cmd = [
+                "rnaseq_grid_violin_plots_cufflinks",
+                superclass_mapping,
+                genome_counts,
+                metadata,
+                superclass_figure,
+            ]
             if os.path.exists(superclass_mapping):
-                print('Running command:\n{0}'.format(' '.join(superclass_cmd)))
+                print("Running command:\n{0}".format(" ".join(superclass_cmd)))
                 # TODO: ENABLE
-                subprocess.check_call(superclass_cmd) 
-                #self.genome.add_genome_data('superclass_figure',superclass_figure+'.svg')
-                self.genome.add_genome_data('superclass_figure',superclass_figure+'.png')
+                subprocess.check_call(superclass_cmd)
+                # self.genome.add_genome_data('superclass_figure',superclass_figure+'.svg')
+                self.genome.add_genome_data(
+                    "superclass_figure", superclass_figure + ".png"
+                )
         except Exception as e:
-            sys.stderr.write('Error creating superclass violin plots:\n{0}\n'.format(e))
+            sys.stderr.write("Error creating superclass violin plots:\n{0}\n".format(e))
         try:
-            pathway_figure = os.path.join(self.genome.get_genome_data('report_img_path'),"PathwayClass_Distribution")
-            pathway_cmd = ["rnaseq_grid_violin_plots_cufflinks",pathway_mapping,genome_counts,metadata,pathway_figure]
+            pathway_figure = os.path.join(
+                self.genome.get_genome_data("report_img_path"),
+                "PathwayClass_Distribution",
+            )
+            pathway_cmd = [
+                "rnaseq_grid_violin_plots_cufflinks",
+                pathway_mapping,
+                genome_counts,
+                metadata,
+                pathway_figure,
+            ]
             if os.path.exists(pathway_mapping):
-                print('Running command:\n{0}'.format(' '.join(pathway_cmd)))
+                print("Running command:\n{0}".format(" ".join(pathway_cmd)))
                 # TODO: ENABLE
-                subprocess.check_call(pathway_cmd) 
-                #self.genome.add_genome_data('pathway_figure',pathway_figure+'.svg')
-                self.genome.add_genome_data('pathway_figure',pathway_figure+'.png')
+                subprocess.check_call(pathway_cmd)
+                # self.genome.add_genome_data('pathway_figure',pathway_figure+'.svg')
+                self.genome.add_genome_data("pathway_figure", pathway_figure + ".png")
         except Exception as e:
-            sys.stderr.write('Error creating pathway violin plots:\n{0}\n'.format(e))
+            sys.stderr.write("Error creating pathway violin plots:\n{0}\n".format(e))
 
     def run_pathway(self, output_dir, session):
-        #pathway_df = getPathwayDataFrame([self.genome.get_id()], session)
+        # pathway_df = getPathwayDataFrame([self.genome.get_id()], session)
         base = "https://www.bv-brc.org/api/pathway/?http_download=true"
         query = f"eq(genome_id,{self.genome.get_id()})&sort(+id)&limit(2500000)"
-        headers = {"accept":"application/json", "content-type":"application/rqlquery+x-www-form-urlencoded", 'Authorization': session.headers['Authorization']}
-        pathway_df = pd.DataFrame(json.loads(getQueryDataText(base,query,headers)))
+        headers = {
+            "accept": "application/json",
+            "content-type": "application/rqlquery+x-www-form-urlencoded",
+            "Authorization": session.headers["Authorization"],
+        }
+        pathway_df = pd.DataFrame(json.loads(getQueryDataText(base, query, headers)))
         if not pathway_df is None:
-            mapping_table = pathway_df[['patric_id','pathway_class']]
-            mapping_output = os.path.join(output_dir,"pathway_mapping.tsv")
-            mapping_table.to_csv(mapping_output,sep='\t',index=False)
-            self.genome.add_genome_data('pathway_mapping',mapping_output)
+            mapping_table = pathway_df[["patric_id", "pathway_class"]]
+            mapping_output = os.path.join(output_dir, "pathway_mapping.tsv")
+            mapping_table.to_csv(mapping_output, sep="\t", index=False)
+            self.genome.add_genome_data("pathway_mapping", mapping_output)
         else:
-            sys.stderr.write('Error, pathway_df is None')
+            sys.stderr.write("Error, pathway_df is None")
             return -1
 
     # subsystem_df is a pandas dataframe
     def run_subsystems(self, output_dir, session):
-        #subsystem_df = getSubsystemsDataFrame([self.genome.get_id()],session)
+        # subsystem_df = getSubsystemsDataFrame([self.genome.get_id()],session)
         base = "https://www.bv-brc.org/api/subsystem/?http_download=true"
         query = f"eq(genome_id,{self.genome.get_id()})&sort(+id)&limit(2500000)"
-        headers = {"accept":"application/json", "content-type":"application/rqlquery+x-www-form-urlencoded", 'Authorization': session.headers['Authorization']} 
+        headers = {
+            "accept": "application/json",
+            "content-type": "application/rqlquery+x-www-form-urlencoded",
+            "Authorization": session.headers["Authorization"],
+        }
         try:
-            subsystem_df = pd.DataFrame(json.loads(getQueryDataText(base,query,headers)))
+            subsystem_df = pd.DataFrame(
+                json.loads(getQueryDataText(base, query, headers))
+            )
         except Exception as e:
-            sys.stderr.write(f'Error retrieving subsystems data:\n{e}\n')
+            sys.stderr.write(f"Error retrieving subsystems data:\n{e}\n")
             return -1
         if not subsystem_df is None:
-            mapping_table = subsystem_df[['patric_id','superclass']]
-            mapping_output = os.path.join(output_dir,"superclass_mapping.tsv")
-            mapping_table.to_csv(mapping_output,sep='\t',index=False)
-            self.genome.add_genome_data('superclass_mapping',mapping_output)
+            mapping_table = subsystem_df[["patric_id", "superclass"]]
+            mapping_output = os.path.join(output_dir, "superclass_mapping.tsv")
+            mapping_table.to_csv(mapping_output, sep="\t", index=False)
+            self.genome.add_genome_data("superclass_mapping", mapping_output)
         else:
-            sys.stderr.write('Error, subsystem_df is None')
+            sys.stderr.write("Error, subsystem_df is None")
             return -1
 
-class Quantify:
 
+class Quantify:
     genome = None
     recipe = None
 
     def __init__(self):
-        print("Creating Quantify manager") 
-    
-    def set_genome(self,g):
+        print("Creating Quantify manager")
+
+    def set_genome(self, g):
         self.genome = g
 
-    def set_recipe(self,r):
+    def set_recipe(self, r):
         self.recipe = r
 
     def run_quantification(self, sample_list, threads):
         if self.recipe is None:
-            sys.stderr.write('Recipe is None: set recipe with set_recipe()')
+            sys.stderr.write("Recipe is None: set recipe with set_recipe()")
             return False
-        if self.recipe == 'HTSeq-DESeq':
+        if self.recipe == "HTSeq-DESeq":
             htseq_ret = self.run_htseq(sample_list, threads)
             if htseq_ret != 0:
                 return htseq_ret
             return self.run_tpmcalc(sample_list, threads)
-        elif self.recipe == 'Host':
+        elif self.recipe == "Host":
             self.run_stringtie(sample_list, threads)
-        elif self.recipe == 'cufflinks':
-            self.run_cufflinks(sample_list, threads)            
+        elif self.recipe == "cufflinks":
+            self.run_cufflinks(sample_list, threads)
         else:
             sys.stderr.write("Invalid recipe: {0}".format(self.recipe))
-            return -1 
+            return -1
 
     def run_tpmcalc(self, sample_list, threads):
         tpm_calc_list = []
         sample_details_list = []
-        genome_gtf = self.genome.get_genome_data('gtf')
+        genome_gtf = self.genome.get_genome_data("gtf")
         for sample in sample_list:
-            bam_file = sample.get_sample_data('bam')
-            tpm_cmd = ['TPMCalculator','-g',genome_gtf,'-b',bam_file]
-            if self.genome.get_genome_type() == 'host':
-                tpm_cmd += ['-e']
-            if self.genome.get_genome_type() == 'bacteria':
-                tpm_cmd += ['-k','gene_name']            
-            tpm_output = os.path.join(self.genome.get_sample_path(sample.get_id()),'tpm_counts.tsv') 
-            sample_details_list.append([tpm_output,sample])
-            tpm_calc_list.append(tpm_cmd) 
+            bam_file = sample.get_sample_data("bam")
+            tpm_cmd = ["TPMCalculator", "-g", genome_gtf, "-b", bam_file]
+            if self.genome.get_genome_type() == "host":
+                tpm_cmd += ["-e"]
+            if self.genome.get_genome_type() == "bacteria":
+                tpm_cmd += ["-k", "gene_name"]
+            tpm_output = os.path.join(
+                self.genome.get_sample_path(sample.get_id()), "tpm_counts.tsv"
+            )
+            sample_details_list.append([tpm_output, sample])
+            tpm_calc_list.append(tpm_cmd)
         tpm_args_list = list(zip(tpm_calc_list, sample_details_list))
         future_returns = []
         # TPMCalculator outputs to current directory
-        if not os.path.exists('TPMCalculator'):
-            os.mkdir('TPMCalculator')
-        os.chdir('TPMCalculator')
+        if not os.path.exists("TPMCalculator"):
+            os.mkdir("TPMCalculator")
+        os.chdir("TPMCalculator")
         with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as pool:
-            future_returns = list(pool.map(self.run_tpmcalc_job,tpm_args_list))
-        os.chdir('../')
+            future_returns = list(pool.map(self.run_tpmcalc_job, tpm_args_list))
+        os.chdir("../")
         for f in future_returns:
             if f != 0:
-                sys.stderr.write('Error in HTSeq-count: check logs\n')
-                sys.stderr.write('{0}\n'.format(future_returns))
+                sys.stderr.write("Error in HTSeq-count: check logs\n")
+                sys.stderr.write("{0}\n".format(future_returns))
                 return -1
-        return 0 
+        return 0
 
     def run_tpmcalc_job(self, cmd_details):
         cmd = cmd_details[0]
         sample_details = cmd_details[1]
         sample = sample_details[1]
-        sample.add_command("tpmcalc"+"_"+self.genome.get_id(),cmd,"running")
-        print('Running command:\n{0}\n'.format(' '.join(cmd)))
+        sample.add_command("tpmcalc" + "_" + self.genome.get_id(), cmd, "running")
+        print("Running command:\n{0}\n".format(" ".join(cmd)))
         try:
             # TODO: ENABLE
             subprocess.check_call(cmd)
-            sample.set_command_status("tpmcalc"+"_"+self.genome.get_id(),"finished")
-            output_file = os.path.abspath(sample.get_id()+'_genes.out')
+            sample.set_command_status(
+                "tpmcalc" + "_" + self.genome.get_id(), "finished"
+            )
+            output_file = os.path.abspath(sample.get_id() + "_genes.out")
             if not os.path.exists(output_file):
-                sys.stderr.write('TPMCalculator output file does not exist:\n{0}\n'.format(output_file))
-            sample.add_sample_data(self.genome.get_id()+"_tpm_out",output_file)
+                sys.stderr.write(
+                    "TPMCalculator output file does not exist:\n{0}\n".format(
+                        output_file
+                    )
+                )
+            sample.add_sample_data(self.genome.get_id() + "_tpm_out", output_file)
         except Exception as e:
-            sys.stderr.write('Error running concurrent tpm job:{0}'.format(e))
-            sample.set_command_status("tpm"+"_"+self.genome.get_id(),e)
+            sys.stderr.write("Error running concurrent tpm job:{0}".format(e))
+            sample.set_command_status("tpm" + "_" + self.genome.get_id(), e)
             return -1
         return 0
 
     def run_htseq(self, sample_list, threads):
         # TODO: add strandedness parameter: -s
         # featurey_type: CDS or Gene
-        quant_cmd_list = [] 
-        annotation_file = self.genome.get_genome_data('annotation')
+        quant_cmd_list = []
+        annotation_file = self.genome.get_genome_data("annotation")
         sample_details_list = []
         for sample in sample_list:
-            bam_file = sample.get_sample_data('bam')
-            quant_cmd = ['htseq-count','-n',str(threads),'-t','gene','-f','bam','-r','pos','-i','ID',bam_file,annotation_file]
+            bam_file = sample.get_sample_data("bam")
+            quant_cmd = [
+                "htseq-count",
+                "-n",
+                str(threads),
+                "-t",
+                "gene",
+                "-f",
+                "bam",
+                "-r",
+                "pos",
+                "-i",
+                "ID",
+                bam_file,
+                annotation_file,
+            ]
             quant_cmd_list.append(quant_cmd)
             sample_dir = self.genome.get_sample_path(sample.get_id())
-            sample_output_file = os.path.join(sample_dir,sample.get_id()+'.counts')
-            sample_err_file = os.path.join(sample_dir,sample.get_id()+'.htseq_err')
-            sample_details_list.append([sample_output_file, sample,sample_err_file])
-        quant_args_list = list(zip(quant_cmd_list,sample_details_list)) 
+            sample_output_file = os.path.join(sample_dir, sample.get_id() + ".counts")
+            sample_err_file = os.path.join(sample_dir, sample.get_id() + ".htseq_err")
+            sample_details_list.append([sample_output_file, sample, sample_err_file])
+        quant_args_list = list(zip(quant_cmd_list, sample_details_list))
         future_returns = []
-        # redirect stderr 
+        # redirect stderr
         with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as pool:
-            future_returns = list(pool.map(self.run_htseq_job,quant_args_list))
+            future_returns = list(pool.map(self.run_htseq_job, quant_args_list))
         for f in future_returns:
             if f != 0:
-                sys.stderr.write('Error in HTSeq-count: check logs\n')
-                sys.stderr.write('{0}\n'.format(future_returns))
+                sys.stderr.write("Error in HTSeq-count: check logs\n")
+                sys.stderr.write("{0}\n".format(future_returns))
                 return -1
-        return 0 
-            
-    def run_htseq_job(self,cmd_details):
+        return 0
+
+    def run_htseq_job(self, cmd_details):
         cmd = cmd_details[0]
         sample_details = cmd_details[1]
         output_file = sample_details[0]
         sample = sample_details[1]
         err_file = sample_details[2]
-        sample.add_command("htseq"+"_"+self.genome.get_id(),cmd,"running")
-        print('Running command:\n{0}\n'.format(' '.join(cmd)))
+        sample.add_command("htseq" + "_" + self.genome.get_id(), cmd, "running")
+        print("Running command:\n{0}\n".format(" ".join(cmd)))
         try:
             # TODO: ENABLE
-            with open(output_file,'w') as o,open(err_file,'w') as e:
-               subprocess.check_call(cmd,stdout=o,stderr=e)
-            sample.set_command_status("htseq"+"_"+self.genome.get_id(),"finished")
-            sample.add_sample_data(self.genome.get_id()+"_gene_counts",output_file)
+            with open(output_file, "w") as o, open(err_file, "w") as e:
+                subprocess.check_call(cmd, stdout=o, stderr=e)
+            sample.set_command_status("htseq" + "_" + self.genome.get_id(), "finished")
+            sample.add_sample_data(self.genome.get_id() + "_gene_counts", output_file)
         except Exception as e:
-            sys.stderr.write('Error running concurrent htseq job:{0}'.format(e))
-            sample.set_command_status("htseq"+"_"+self.genome.get_id(),e)
+            sys.stderr.write("Error running concurrent htseq job:{0}".format(e))
+            sample.set_command_status("htseq" + "_" + self.genome.get_id(), e)
             return -1
         return 0
-    
-    def create_genome_counts_table(self,output_dir,sample_list):
-        if self.recipe == 'HTSeq-DESeq':
-            return self.create_genome_counts_table_htseq(output_dir,sample_list)
-        elif self.recipe == 'Host':
-            return self.create_genome_counts_table_stringtie(output_dir,sample_list)
-        elif self.recipe == 'cufflinks':
-            return self.create_genome_counts_table_cufflinks(output_dir,sample_list,8)
+
+    def create_genome_counts_table(self, output_dir, sample_list):
+        if self.recipe == "HTSeq-DESeq":
+            return self.create_genome_counts_table_htseq(output_dir, sample_list)
+        elif self.recipe == "Host":
+            return self.create_genome_counts_table_stringtie(output_dir, sample_list)
+        elif self.recipe == "cufflinks":
+            return self.create_genome_counts_table_cufflinks(output_dir, sample_list, 8)
         else:
-            sys.stderr.write('No counts table method found for recipe {0}\n'.format(self.recipe))
+            sys.stderr.write(
+                "No counts table method found for recipe {0}\n".format(self.recipe)
+            )
             return None
 
-    def create_genome_counts_table_cufflinks(self,output_dir,sample_list,threads):
+    def create_genome_counts_table_cufflinks(self, output_dir, sample_list, threads):
         gtf_list = []
         for sample in sample_list:
-            gtf_list.append(sample.get_sample_data('cuff_gtf'))            
+            gtf_list.append(sample.get_sample_data("cuff_gtf"))
         # run cuffmerge to produce a top-level transcripts.gtf file
-        cuffmerge_cmd = ['cuffmerge','-p',str(threads)]
-        ref_gtf = self.genome.get_genome_data('gtf')
+        cuffmerge_cmd = ["cuffmerge", "-p", str(threads)]
+        ref_gtf = self.genome.get_genome_data("gtf")
         if ref_gtf is not None:
-            cuffmerge_cmd += ['-g',ref_gtf]
-        ref_fasta = self.genome.get_genome_data('fasta')
+            cuffmerge_cmd += ["-g", ref_gtf]
+        ref_fasta = self.genome.get_genome_data("fasta")
         if ref_fasta is not None:
-            cuffmerge_cmd += ['-s',ref_fasta]
-        with open('assembly_list.txt','w') as o:
-            o.write('{0}\n'.format('\n'.join(gtf_list)))
-        cuffmerge_cmd.append('assembly_list.txt')
+            cuffmerge_cmd += ["-s", ref_fasta]
+        with open("assembly_list.txt", "w") as o:
+            o.write("{0}\n".format("\n".join(gtf_list)))
+        cuffmerge_cmd.append("assembly_list.txt")
         print("Running command:\n{0}".format(" ".join(cuffmerge_cmd)))
-        merged_gtf = os.path.join(output_dir,'merged_asm/merged.gtf')
-        try: 
-            subprocess.check_call(cuffmerge_cmd) 
-            self.genome.add_genome_data('merge_gtf',merged_gtf)
+        merged_gtf = os.path.join(output_dir, "merged_asm/merged.gtf")
+        try:
+            subprocess.check_call(cuffmerge_cmd)
+            self.genome.add_genome_data("merge_gtf", merged_gtf)
         except Exception as e:
-            sys.stderr.write('Error running cuffmerge:\n{0}\n'.format(e))
+            sys.stderr.write("Error running cuffmerge:\n{0}\n".format(e))
             return False
 
-        #cuffquant [options] <transcripts.gtf> <sample1_hits.sam> <sample2_hits.sam> [... sampleN_hits.sam]
-        cuffquant_cmd = ['cuffquant','-o',output_dir,'-p',str(threads),self.genome.get_genome_data('annotation')]
+        # cuffquant [options] <transcripts.gtf> <sample1_hits.sam> <sample2_hits.sam> [... sampleN_hits.sam]
+        cuffquant_cmd = [
+            "cuffquant",
+            "-o",
+            output_dir,
+            "-p",
+            str(threads),
+            self.genome.get_genome_data("annotation"),
+        ]
         # TODO: add strandedness to command
         for sample in sample_list:
-            cuffquant_cmd += [sample.get_sample_data('bam')] 
-        abundance_file = os.path.join(output_dir,'abundances.cxb')
-        print('Running command:\n{0}\n'.format(' '.join(cuffquant_cmd)))
+            cuffquant_cmd += [sample.get_sample_data("bam")]
+        abundance_file = os.path.join(output_dir, "abundances.cxb")
+        print("Running command:\n{0}\n".format(" ".join(cuffquant_cmd)))
         try:
             subprocess.check_call(cuffquant_cmd)
-            self.genome.add_genome_data('cxb',abundance_file)
+            self.genome.add_genome_data("cxb", abundance_file)
         except Exception as e:
-            sys.stderr.write('Error running cuffquant\n')
-            return -1 
+            sys.stderr.write("Error running cuffquant\n")
+            return -1
         # TODO: rename output file?
         return 0
 
     # Call rnaseqPrepDE.py script which formats data in the gtf files as a table
     # https://ccb.jhu.edu/software/stringtie/index.shtml?t=manual
-    def create_genome_counts_table_stringtie(self,output_dir,sample_list):
+    def create_genome_counts_table_stringtie(self, output_dir, sample_list):
         # create input file for -i option
         output_text_list = []
         avg_len_list = []
         for sample in sample_list:
-            gtf_path = sample.get_sample_data(self.genome.get_id()+'_merged_transcripts')
-            text = sample.get_id() + ' ' + gtf_path
+            gtf_path = sample.get_sample_data(
+                self.genome.get_id() + "_merged_transcripts"
+            )
+            text = sample.get_id() + " " + gtf_path
             output_text_list.append(text)
-            avg_len_list.append(int(sample.get_sample_data('avg_read_length')))
-        output_text = '\n'.join(output_text_list) + '\n'
-        path_file = os.path.join(output_dir,'sample_transcript_paths.txt')
-        with open(path_file,'w') as o:
+            avg_len_list.append(int(sample.get_sample_data("avg_read_length")))
+        output_text = "\n".join(output_text_list) + "\n"
+        path_file = os.path.join(output_dir, "sample_transcript_paths.txt")
+        with open(path_file, "w") as o:
             o.write(output_text)
-        # run rnaseqPrepDE.py 
-        gene_matrix_file = os.path.join(output_dir,"gene_counts_matrix.csv")
-        transcript_matrix_file = os.path.join(output_dir,"transcript_counts_matrix.csv")
-        avg_read_length = int(np.average(avg_len_list)) 
+        # run rnaseqPrepDE.py
+        gene_matrix_file = os.path.join(output_dir, "gene_counts_matrix.csv")
+        transcript_matrix_file = os.path.join(
+            output_dir, "transcript_counts_matrix.csv"
+        )
+        avg_read_length = int(np.average(avg_len_list))
         if avg_read_length == 0:
-            sys.stderr.write('Error creating gene and transcript counts table: average read length is 0.\n')
+            sys.stderr.write(
+                "Error creating gene and transcript counts table: average read length is 0.\n"
+            )
             return None
         # TODO: set path or import or something
-        prepde_cmd = ['rnaseqPrepDE','-i',path_file,'-g',gene_matrix_file,'-t',transcript_matrix_file,'l',str(avg_read_length)]
+        prepde_cmd = [
+            "rnaseqPrepDE",
+            "-i",
+            path_file,
+            "-g",
+            gene_matrix_file,
+            "-t",
+            transcript_matrix_file,
+            "l",
+            str(avg_read_length),
+        ]
         try:
-            print(' '.join(prepde_cmd))
+            print(" ".join(prepde_cmd))
             subprocess.check_call(prepde_cmd)
-            self.genome.add_genome_data(self.genome.get_id()+"_gene_counts",gene_matrix_file)
-            self.genome.add_genome_data(self.genome.get_id()+"_transcript_counts",transcript_matrix_file)
+            self.genome.add_genome_data(
+                self.genome.get_id() + "_gene_counts", gene_matrix_file
+            )
+            self.genome.add_genome_data(
+                self.genome.get_id() + "_transcript_counts", transcript_matrix_file
+            )
         except Exception as e:
-            sys.stderr.write('Error in rnaseqPrepDE.py: cannot generate genome counts or transcript counts file') 
+            sys.stderr.write(
+                "Error in rnaseqPrepDE.py: cannot generate genome counts or transcript counts file"
+            )
             sys.exit(-1)
-        
-    def create_genome_counts_table_htseq(self,output_dir,sample_list):
+
+    def create_genome_counts_table_htseq(self, output_dir, sample_list):
         genome_df = None
         for sample in sample_list:
-            sample_df = pd.read_csv(sample.get_sample_data(self.genome.get_id()+"_gene_counts"),delim_whitespace=True,index_col=0,header=None,names=[sample.get_id()])
+            sample_df = pd.read_csv(
+                sample.get_sample_data(self.genome.get_id() + "_gene_counts"),
+                delim_whitespace=True,
+                index_col=0,
+                header=None,
+                names=[sample.get_id()],
+            )
             if genome_df is None:
                 genome_df = sample_df
             else:
                 genome_df = genome_df.join(sample_df)
-        output_file = os.path.join(output_dir,'gene_counts_matrix.tsv')
-        genome_df.to_csv(output_file,sep='\t')
-        self.genome.add_genome_data(self.genome.get_id()+'_gene_counts',output_file)
+        output_file = os.path.join(output_dir, "gene_counts_matrix.tsv")
+        genome_df.to_csv(output_file, sep="\t")
+        self.genome.add_genome_data(self.genome.get_id() + "_gene_counts", output_file)
         return output_file
 
     def create_genome_quant_table(self, output_dir, sample_list):
-        if self.recipe == 'HTSeq-DESeq':
-            return self.create_tpm_table_tpmcalculator(output_dir,sample_list)
-        elif self.recipe == 'Host':
-            return self.create_tpm_table_stringtie(output_dir,sample_list)
-        elif self.recipe == 'cufflinks':
-            # TODO: testing cuffnorm 
-            return self.create_fpkm_table_cufflinks(output_dir,sample_list)
-            #return None
+        if self.recipe == "HTSeq-DESeq":
+            return self.create_tpm_table_tpmcalculator(output_dir, sample_list)
+        elif self.recipe == "Host":
+            return self.create_tpm_table_stringtie(output_dir, sample_list)
+        elif self.recipe == "cufflinks":
+            # TODO: testing cuffnorm
+            return self.create_fpkm_table_cufflinks(output_dir, sample_list)
+            # return None
 
     # outputs to directory 'cuffnorm_output'
-    def create_fpkm_table_cufflinks(self,output_dir,sample_list):
+    def create_fpkm_table_cufflinks(self, output_dir, sample_list):
         threads = 8
-        merged_gtf = self.genome.get_genome_data('merge_gtf')
-        cuffnorm_outdir = 'cuffnorm_output'
+        merged_gtf = self.genome.get_genome_data("merge_gtf")
+        cuffnorm_outdir = "cuffnorm_output"
         if not os.path.exists(cuffnorm_outdir):
             os.mkdir(cuffnorm_outdir)
         # TODO: add library-type
-        cuffnorm_cmd = ['cuffnorm','-p','1','-o',cuffnorm_outdir,'-library-norm-method','classic-fpkm',merged_gtf]
+        cuffnorm_cmd = [
+            "cuffnorm",
+            "-p",
+            "1",
+            "-o",
+            cuffnorm_outdir,
+            "-library-norm-method",
+            "classic-fpkm",
+            merged_gtf,
+        ]
         sam_dict = {}
         condition_list = []
         sample_id_list = []
         for sample in sample_list:
-            sample_condition = sample.get_condition() 
+            sample_condition = sample.get_condition()
             sample_id_list.append(sample.get_id())
             if sample_condition not in sam_dict:
                 sam_dict[sample_condition] = []
                 condition_list.append(sample_condition)
-            sam_dict[sample_condition].append(sample.get_sample_data('bam'))
+            sam_dict[sample_condition].append(sample.get_sample_data("bam"))
         for sample_condition in sam_dict:
-            cuffnorm_cmd += [','.join(sam_dict[sample_condition])]
+            cuffnorm_cmd += [",".join(sam_dict[sample_condition])]
         try:
-            cuffnorm_err = os.path.join(output_dir,'cuffnorm_output.err') 
-            print('Running command:\n{0}\n'.format(' '.join(cuffnorm_cmd)))
-            with open(cuffnorm_err,'w') as err:
-                subprocess.check_call(cuffnorm_cmd,stderr=err)
+            cuffnorm_err = os.path.join(output_dir, "cuffnorm_output.err")
+            print("Running command:\n{0}\n".format(" ".join(cuffnorm_cmd)))
+            with open(cuffnorm_err, "w") as err:
+                subprocess.check_call(cuffnorm_cmd, stderr=err)
         except Exception as e:
-            sys.stderr.write('Error running cuffnorm:\n{0}\n'.format(e))
+            sys.stderr.write("Error running cuffnorm:\n{0}\n".format(e))
             return -1
         # create fpkm matrix
         try:
-            fpkm_file = os.path.join(output_dir,'cuffnorm_output/genes.fpkm_table')
+            fpkm_file = os.path.join(output_dir, "cuffnorm_output/genes.fpkm_table")
             if not os.path.exists(fpkm_file):
-                sys.stderr.write(f'Error running cuffnorm: {fpkm_file} oes not exist\n')
+                sys.stderr.write(f"Error running cuffnorm: {fpkm_file} oes not exist\n")
                 return -1
-            attr_file = os.path.join(output_dir,'cuffnorm_output/genes.attr_table')
+            attr_file = os.path.join(output_dir, "cuffnorm_output/genes.attr_table")
             if not os.path.exists(attr_file):
-                sys.stderr.write(f'Error running cuffnorm: {attr_file} oes not exist\n')
+                sys.stderr.write(f"Error running cuffnorm: {attr_file} oes not exist\n")
                 return -1
             # print(f'fpkm_file = {fpkm_file}')
             attr_dict = {}
-            with open(attr_file,'r') as af: 
+            with open(attr_file, "r") as af:
                 af_data = af.readlines()
-                af_headers = af_data[0].strip().split('\t')
-                for idx,af_line in enumerate(af_data):
+                af_headers = af_data[0].strip().split("\t")
+                for idx, af_line in enumerate(af_data):
                     if idx == 0:
-                        continue 
-                    af_line_parts = af_line.strip().split('\t')
+                        continue
+                    af_line_parts = af_line.strip().split("\t")
                     attr_dict[af_line_parts[0]] = af_line_parts[4]
             fpkm_output_list = []
-            fpkm_header = ["Gene_ID"] + sample_id_list 
-            fpkm_output_list.append('\t'.join(fpkm_header))
-            with open(fpkm_file,'r') as ff: 
+            fpkm_header = ["Gene_ID"] + sample_id_list
+            fpkm_output_list.append("\t".join(fpkm_header))
+            with open(fpkm_file, "r") as ff:
                 ff_data = ff.readlines()
-                for idx,ff_line in enumerate(ff_data):
+                for idx, ff_line in enumerate(ff_data):
                     if idx == 0:
                         continue
                     ff_line_parts = ff_line.strip().split()
-                    new_line = attr_dict[ff_line_parts[0]] + '\t' + '\t'.join(ff_line_parts[1:])
+                    new_line = (
+                        attr_dict[ff_line_parts[0]]
+                        + "\t"
+                        + "\t".join(ff_line_parts[1:])
+                    )
                     fpkm_output_list.append(new_line)
-            fpkm_output = os.path.join(output_dir,"fpkm_counts_matrix.tsv")
-            fpkm_output_data = '\n'.join(fpkm_output_list)
-            with open(fpkm_output,'w') as o:
+            fpkm_output = os.path.join(output_dir, "fpkm_counts_matrix.tsv")
+            fpkm_output_data = "\n".join(fpkm_output_list)
+            with open(fpkm_output, "w") as o:
                 o.write(fpkm_output_data)
-            self.genome.add_genome_data('fpkm',fpkm_output)
+            self.genome.add_genome_data("fpkm", fpkm_output)
         except Exception as e:
-            sys.stderr.write('Error parsing fpkm table:\n{0}\n'.format(e))
+            sys.stderr.write("Error parsing fpkm table:\n{0}\n".format(e))
             return -1
 
     def create_tpm_table_tpmcalculator(self, output_dir, sample_list):
         genome_df = None
         for sample in sample_list:
-            sample_df = pd.read_csv(sample.get_sample_data(self.genome.get_id()+'_tpm_out'),delim_whitespace=True)
-            sample_df = sample_df[['Gene_Id','TPM']]
-            sample_df.rename(columns={'Gene_Id':'Gene_Id','TPM':sample.get_id()}, inplace=True)
+            sample_df = pd.read_csv(
+                sample.get_sample_data(self.genome.get_id() + "_tpm_out"),
+                delim_whitespace=True,
+            )
+            sample_df = sample_df[["Gene_Id", "TPM"]]
+            sample_df.rename(
+                columns={"Gene_Id": "Gene_Id", "TPM": sample.get_id()}, inplace=True
+            )
             if genome_df is None:
                 genome_df = sample_df
             else:
-                genome_df = genome_df.merge(sample_df,how='outer',on='Gene_Id')
+                genome_df = genome_df.merge(sample_df, how="outer", on="Gene_Id")
         genome_df = genome_df.fillna(0)
-        genome_df.set_index('Gene_Id',inplace=True)
-        output_file = os.path.join(output_dir,"tpm_counts_matrix.tsv")
-        genome_df.to_csv(output_file,sep='\t')
-        self.genome.add_genome_data('tpm',output_file)
+        genome_df.set_index("Gene_Id", inplace=True)
+        output_file = os.path.join(output_dir, "tpm_counts_matrix.tsv")
+        genome_df.to_csv(output_file, sep="\t")
+        self.genome.add_genome_data("tpm", output_file)
 
-    def create_tpm_table_stringtie(self,output_dir,sample_list):
+    def create_tpm_table_stringtie(self, output_dir, sample_list):
         genome_df = None
         for sample in sample_list:
-            sample_df = pd.read_csv(sample.get_sample_data(self.genome.get_id()+'_merged_gene_counts'),sep='\t')
-            sample_df = sample_df.loc[sample_df['Gene ID'] != '.']
-            sample_df = sample_df[['Gene ID','TPM']]
-            sample_df.rename(columns={'Gene ID':'Gene_Id','TPM':sample.get_id()}, inplace=True)
+            sample_df = pd.read_csv(
+                sample.get_sample_data(self.genome.get_id() + "_merged_gene_counts"),
+                sep="\t",
+            )
+            sample_df = sample_df.loc[sample_df["Gene ID"] != "."]
+            sample_df = sample_df[["Gene ID", "TPM"]]
+            sample_df.rename(
+                columns={"Gene ID": "Gene_Id", "TPM": sample.get_id()}, inplace=True
+            )
             if genome_df is None:
                 genome_df = sample_df
             else:
-                genome_df = genome_df.merge(sample_df,how='outer',on='Gene_Id')
+                genome_df = genome_df.merge(sample_df, how="outer", on="Gene_Id")
             genome_df = genome_df.fillna(0)
-            genome_df.set_index('Gene_Id', inplace=True)
-            output_file = os.path.join(output_dir,"tpm_counts_matrix.tsv")
-            genome_df.to_csv(output_file,sep='\t')
-            self.genome.add_genome_data('tpm',output_file)
+            genome_df.set_index("Gene_Id", inplace=True)
+            output_file = os.path.join(output_dir, "tpm_counts_matrix.tsv")
+            genome_df.to_csv(output_file, sep="\t")
+            self.genome.add_genome_data("tpm", output_file)
 
-    # TODO: for all sample stuff replace sample.get_id() with self.genome.get_id() 
+    # TODO: for all sample stuff replace sample.get_id() with self.genome.get_id()
     def run_stringtie(self, sample_list, threads):
-        annotation_file = self.genome.get_genome_data('annotation')
+        annotation_file = self.genome.get_genome_data("annotation")
         gtf_list = []
-        print('sample_list = [{0}],'.format(sample_list))
+        print("sample_list = [{0}],".format(sample_list))
         for sample in sample_list:
-            bam_file = sample.get_sample_data('bam')
+            bam_file = sample.get_sample_data("bam")
             sample_dir = self.genome.get_sample_path(sample.get_id())
 
-            gene_output = os.path.join(sample_dir,'gene_abund.tab')
-            gtf_output = os.path.join(sample_dir,'transcripts.gtf')
+            gene_output = os.path.join(sample_dir, "gene_abund.tab")
+            gtf_output = os.path.join(sample_dir, "transcripts.gtf")
             gtf_list.append(gtf_output)
-            # not including -e (included below), including restricts novel feature prediction 
-            quant_cmd = ['stringtie',bam_file,'-p',str(threads),'-A',gene_output,'-G',annotation_file,'-o',gtf_output]
+            # not including -e (included below), including restricts novel feature prediction
+            quant_cmd = [
+                "stringtie",
+                bam_file,
+                "-p",
+                str(threads),
+                "-A",
+                gene_output,
+                "-G",
+                annotation_file,
+                "-o",
+                gtf_output,
+            ]
             if not os.path.exists(gtf_output) or True:
-                sample.add_command("stringtie_"+self.genome.get_id(),quant_cmd,"running")
-                print('Running command:\n{0}\n'.format(' '.join(quant_cmd))) 
+                sample.add_command(
+                    "stringtie_" + self.genome.get_id(), quant_cmd, "running"
+                )
+                print("Running command:\n{0}\n".format(" ".join(quant_cmd)))
                 try:
                     subprocess.check_call(quant_cmd)
-                    sample.set_command_status('stringtie_'+self.genome.get_id(),'finished')
-                    sample.add_sample_data(self.genome.get_id()+'_gene_counts',gene_output)
-                    sample.add_sample_data(self.genome.get_id()+'_transcripts',gtf_output)
+                    sample.set_command_status(
+                        "stringtie_" + self.genome.get_id(), "finished"
+                    )
+                    sample.add_sample_data(
+                        self.genome.get_id() + "_gene_counts", gene_output
+                    )
+                    sample.add_sample_data(
+                        self.genome.get_id() + "_transcripts", gtf_output
+                    )
                 except Exception as e:
-                    sys.stderr.write('Error running stringtie:\n{0}\n'.format(e))
-                    sample.set_command_status('stringtie_'+self.genome.get_id(),e)
+                    sys.stderr.write("Error running stringtie:\n{0}\n".format(e))
+                    sample.set_command_status("stringtie_" + self.genome.get_id(), e)
                     return -1
             else:
-                sys.stderr.write('{0} already exists: skipping stringtie'.format(gtf_output))
+                sys.stderr.write(
+                    "{0} already exists: skipping stringtie".format(gtf_output)
+                )
         # merge reconstructed transcriptomes
-        merge_file = os.path.join(self.genome.get_genome_dir(),'merged.gtf')
+        merge_file = os.path.join(self.genome.get_genome_dir(), "merged.gtf")
         if not os.path.exists(merge_file) or True:
-            merge_cmd = ['stringtie','--merge','-G',annotation_file,'-o',merge_file] + gtf_list
+            merge_cmd = [
+                "stringtie",
+                "--merge",
+                "-G",
+                annotation_file,
+                "-o",
+                merge_file,
+            ] + gtf_list
             try:
-                print('Running command:\n{0}\n'.format(' '.join(merge_cmd)))
+                print("Running command:\n{0}\n".format(" ".join(merge_cmd)))
                 subprocess.check_call(merge_cmd)
             except Exception as e:
-                sys.stderr.write('ERROR running stringtie-merge:\n{0}'.format(e))
+                sys.stderr.write("ERROR running stringtie-merge:\n{0}".format(e))
                 return -1
-        self.genome.add_genome_data('merged_gtf',merge_file) 
+        self.genome.add_genome_data("merged_gtf", merge_file)
 
         for sample in sample_list:
-            bam_file = sample.get_sample_data('bam')
+            bam_file = sample.get_sample_data("bam")
             sample_dir = self.genome.get_sample_path(sample.get_id())
 
-            gene_output = os.path.join(sample_dir,'merged_gene_abund.tab')
-            gtf_output = os.path.join(sample_dir,'merged_transcripts.gtf')
+            gene_output = os.path.join(sample_dir, "merged_gene_abund.tab")
+            gtf_output = os.path.join(sample_dir, "merged_transcripts.gtf")
             # -e requires using trancripts found in -G (turns off novel feature prediction)
-            quant_cmd = ['stringtie','-e',bam_file,'-p',str(threads),'-A',gene_output,'-G',merge_file,'-o',gtf_output]
+            quant_cmd = [
+                "stringtie",
+                "-e",
+                bam_file,
+                "-p",
+                str(threads),
+                "-A",
+                gene_output,
+                "-G",
+                merge_file,
+                "-o",
+                gtf_output,
+            ]
             if not os.path.exists(gtf_output) or True:
-                sample.add_command('stringtie_merged_'+self.genome.get_id(),quant_cmd,'running')
-                print('Running command:\n{0}\n'.format(' '.join(quant_cmd)))
+                sample.add_command(
+                    "stringtie_merged_" + self.genome.get_id(), quant_cmd, "running"
+                )
+                print("Running command:\n{0}\n".format(" ".join(quant_cmd)))
                 try:
                     subprocess.check_call(quant_cmd)
-                    sample.set_command_status('stringtie_merged_'+self.genome.get_id(),'finished')
-                    sample.add_sample_data(self.genome.get_id()+'_merged_transcripts',gtf_output)
-                    sample.add_sample_data(self.genome.get_id()+'_merged_gene_counts',gene_output)
+                    sample.set_command_status(
+                        "stringtie_merged_" + self.genome.get_id(), "finished"
+                    )
+                    sample.add_sample_data(
+                        self.genome.get_id() + "_merged_transcripts", gtf_output
+                    )
+                    sample.add_sample_data(
+                        self.genome.get_id() + "_merged_gene_counts", gene_output
+                    )
                 except Exception as e:
-                    sys.stderr.write('Error running stringtie-merged:\n{0}\n'.format(e))
-                    sample.set_command_status('stringtie_merged_'+self.genome.get_id(),e)
+                    sys.stderr.write("Error running stringtie-merged:\n{0}\n".format(e))
+                    sample.set_command_status(
+                        "stringtie_merged_" + self.genome.get_id(), e
+                    )
                     return -1
             else:
-                sys.stderr.write('{0} already exists: skipping stringtie merged annotation'.format(gtf_output))
+                sys.stderr.write(
+                    "{0} already exists: skipping stringtie merged annotation".format(
+                        gtf_output
+                    )
+                )
 
-    def run_cufflinks(self,sample_list,threads):
-        reference = self.genome.get_genome_data('fasta')
-        annotation = self.genome.get_genome_data('annotation')
+    def run_cufflinks(self, sample_list, threads):
+        reference = self.genome.get_genome_data("fasta")
+        annotation = self.genome.get_genome_data("annotation")
         threads = 8
         for sample in sample_list:
-            sample_bam = sample.get_sample_data('bam')
-            cufflinks_cmd = ['cufflinks','--quiet','-p',str(threads),'-G',annotation,'-b',reference,'-I','50','-o',self.genome.get_sample_path(sample.get_id())]
+            sample_bam = sample.get_sample_data("bam")
+            cufflinks_cmd = [
+                "cufflinks",
+                "--quiet",
+                "-p",
+                str(threads),
+                "-G",
+                annotation,
+                "-b",
+                reference,
+                "-I",
+                "50",
+                "-o",
+                self.genome.get_sample_path(sample.get_id()),
+            ]
             # Review: Memory mapped location on each system
             # Attempt to copy to /dev/shm. cufflinks seeks a lot in the file.
             # If that fails, try tmp.
@@ -725,55 +962,63 @@ class Quantify:
             bam_to_use = None
 
             try:
-                tmpfd, bam_tmp = tempfile.mkstemp(prefix="CUFFL.",dir="/dev/shm")
+                tmpfd, bam_tmp = tempfile.mkstemp(prefix="CUFFL.", dir="/dev/shm")
                 os.close(tmpfd)
                 shutil.copy(sample_bam, bam_tmp)
-                print ("Copy succeeded to %s" % (bam_tmp))
+                print("Copy succeeded to %s" % (bam_tmp))
                 bam_to_use = bam_tmp
             except IOError as err:
                 os.unlink(bam_tmp)
                 bam_to_use = None
                 bam_tmp = None
-                sys.stderr.write("Can't copy %s to %s: %s\n" % (sample_bam, bam_tmp, err))
+                sys.stderr.write(
+                    "Can't copy %s to %s: %s\n" % (sample_bam, bam_tmp, err)
+                )
 
             if bam_to_use == None:
                 try:
-                    tmpfd, bam_tmp = tempfile.mkstemp(prefix="CUFFL.",dir=".")
+                    tmpfd, bam_tmp = tempfile.mkstemp(prefix="CUFFL.", dir=".")
                     os.close(tmpfd)
                     shutil.copy(sample_bam, bam_tmp)
                     bam_to_use = bam_tmp
-
 
                 except IOError as err:
                     os.unlink(bam_tmp)
                     bam_to_use = None
                     bam_tmp = None
-                    sys.stderr.write("Can't copy %s to %s: %s\n" % (sample_bam, bam_tmp, err))
+                    sys.stderr.write(
+                        "Can't copy %s to %s: %s\n" % (sample_bam, bam_tmp, err)
+                    )
 
-            
             if bam_to_use == None:
                 sys.stderr.write("Can't copy %s to tmp space\n" % (sample_bam))
-                bam_to_use = sample_bam 
+                bam_to_use = sample_bam
                 bam_tmp = None
 
             cufflinks_cmd += [bam_to_use]
-            cuff_gtf = os.path.join(self.genome.get_sample_path(sample.get_id()),'transcripts.gtf')
+            cuff_gtf = os.path.join(
+                self.genome.get_sample_path(sample.get_id()), "transcripts.gtf"
+            )
 
             print("Running command:\n{0}".format(" ".join(cufflinks_cmd)))
             try:
-                subprocess.check_call(cufflinks_cmd) 
-                sample.add_sample_data('cuff_gtf',cuff_gtf)
+                subprocess.check_call(cufflinks_cmd)
+                sample.add_sample_data("cuff_gtf", cuff_gtf)
             except Exception as e:
-                sys.stderr.write('Error running cufflinks on sample {0}:\n{1}\n'.format(sample.get_id(),e))
+                sys.stderr.write(
+                    "Error running cufflinks on sample {0}:\n{1}\n".format(
+                        sample.get_id(), e
+                    )
+                )
                 return False
-            
+
             if bam_tmp != None:
                 sys.stderr.write("remove temp %s\n" % (bam_tmp))
                 os.unlink(bam_tmp)
         return True
 
-class Alignment: 
 
+class Alignment:
     # TODO: check for genome before running functions
     genome = None
     sampled_reads = 2000
@@ -781,53 +1026,75 @@ class Alignment:
 
     def __init__(self):
         print("Creating Alignment manager")
-        
-    def set_genome(self,g):
-        self.genome = g 
+
+    def set_genome(self, g):
+        self.genome = g
 
     def run_alignment(self, sample, threads):
         # TODO: if exists, add strand param to alignment
         sample_dir = self.genome.get_sample_path(sample.get_id())
         print("sample_dir = {0}".format(sample_dir))
         reads_list = sample.get_reads_as_list()
-        sam_file = os.path.join(sample_dir,sample.get_id()+".sam")
-        if self.genome.get_genome_type() == 'bacteria':
-            align_cmd = ["bowtie2","-x",self.genome.get_genome_data("bowtie_prefix")] 
+        sam_file = os.path.join(sample_dir, sample.get_id() + ".sam")
+        if self.genome.get_genome_type() == "bacteria":
+            align_cmd = ["bowtie2", "-x", self.genome.get_genome_data("bowtie_prefix")]
         else:
-            align_cmd = ["hisat2","-x",self.genome.get_genome_data('hisat_prefix'),'--mp','1,0','--pen-noncansplice','20']
+            align_cmd = [
+                "hisat2",
+                "-x",
+                self.genome.get_genome_data("hisat_prefix"),
+                "--mp",
+                "1,0",
+                "--pen-noncansplice",
+                "20",
+            ]
         if sample.sample_type == "paired":
-            align_cmd += ["-1",reads_list[0],"-2",reads_list[1]]
+            align_cmd += ["-1", reads_list[0], "-2", reads_list[1]]
         elif sample.sample_type == "single":
-            align_cmd += ["-U",reads_list[0]]
-        align_cmd += ["-S",sam_file,"-p",str(threads)] 
-        sample.add_command("align"+"_"+self.genome.get_id(),align_cmd,"running") 
-        align_output_file = sam_file.replace('.sam','.align_stdout')
-        print("Running command:\n{0}".format(" ".join(align_cmd))) 
+            align_cmd += ["-U", reads_list[0]]
+        align_cmd += ["-S", sam_file, "-p", str(threads)]
+        sample.add_command("align" + "_" + self.genome.get_id(), align_cmd, "running")
+        align_output_file = sam_file.replace(".sam", ".align_stdout")
+        print("Running command:\n{0}".format(" ".join(align_cmd)))
         try:
             # capture stdout for stats later
             # TODO: ENABLE
-            with open(align_output_file,'w') as o:
-                subprocess.check_call(align_cmd,stderr=o)
+            with open(align_output_file, "w") as o:
+                subprocess.check_call(align_cmd, stderr=o)
             # print captured stdout
-            with open(align_output_file,'r') as aof:
+            with open(align_output_file, "r") as aof:
                 print(aof.read())
-            sample.add_sample_data('sam',sam_file)
-            sample.add_sample_data(self.genome.get_id()+'_align_stats',align_output_file)
+            sample.add_sample_data("sam", sam_file)
+            sample.add_sample_data(
+                self.genome.get_id() + "_align_stats", align_output_file
+            )
             sample.set_alignment_status(True)
-            sample.set_command_status("align"+"_"+self.genome.get_id(),"finished")
+            sample.set_command_status("align" + "_" + self.genome.get_id(), "finished")
         except Exception as e:
-            sys.stderr.write("Sample-alignment encountered an error in Sample {0}:\ncheck error log file\n".format(sample.get_id()))
-            sample.set_command_status("align"+"_"+self.genome.get_id(),e)
+            sys.stderr.write(
+                "Sample-alignment encountered an error in Sample {0}:\ncheck error log file\n".format(
+                    sample.get_id()
+                )
+            )
+            sample.set_command_status("align" + "_" + self.genome.get_id(), e)
             return False
-        
-        bam_file = self.convert_sam_to_bam(sam_file,threads)
+
+        bam_file = self.convert_sam_to_bam(sam_file, threads)
         if bam_file:
-            sample.add_sample_data("bam",bam_file) 
+            sample.add_sample_data("bam", bam_file)
         else:
-            sys.stderr.write("Bam file entry does not exist for Sample {0}:\ncheck error log file\n".format(sample.get_id()))
+            sys.stderr.write(
+                "Bam file entry does not exist for Sample {0}:\ncheck error log file\n".format(
+                    sample.get_id()
+                )
+            )
             return False
         if not os.path.exists(bam_file):
-            sys.stderr.write("Bam file does not exist for Sample {0}:\ncheck error log file\n".format(sample.get_id()))
+            sys.stderr.write(
+                "Bam file does not exist for Sample {0}:\ncheck error log file\n".format(
+                    sample.get_id()
+                )
+            )
             return False
         # remove sam file
         if os.path.exists(sam_file):
@@ -837,158 +1104,222 @@ class Alignment:
     def check_alignment(self, sample):
         # threshold for number of unique read alignments required by each sample to continue the pipeline
         counts_threshold = 1000
-        sample_align_file = sample.get_sample_data(self.genome.get_id()+'_align_stats')
+        sample_align_file = sample.get_sample_data(
+            self.genome.get_id() + "_align_stats"
+        )
         if os.path.exists(sample_align_file):
             try:
                 with open(sample_align_file) as saf:
                     align_data = saf.readlines()
                 for line in align_data:
-                    if 'aligned concordantly exactly 1 time' in line:
+                    if "aligned concordantly exactly 1 time" in line:
                         unique_counts = line.split()[0]
                         if int(unique_counts) < counts_threshold:
                             sample.set_alignment_check(False)
                             return False
                 sample.set_alignment_check(True)
                 return True
-            #407 (0.04%) aligned exactly 1 time
+            # 407 (0.04%) aligned exactly 1 time
             except Exception as err:
-                sys.stderr.write(f"Error checking alignment stats file {sample.get_id()}:\n{err}\n")
+                sys.stderr.write(
+                    f"Error checking alignment stats file {sample.get_id()}:\n{err}\n"
+                )
                 sys.stderr.write("Skipping assessment and hope it works\n")
                 sample.set_alignment_check(False)
                 return True
         else:
-            print(f"alignmnt stats output file does not exist for sample {sample.get_id()}, skipping assessment and hope it works")
+            print(
+                f"alignmnt stats output file does not exist for sample {sample.get_id()}, skipping assessment and hope it works"
+            )
             sample.set_alignment_check(False)
             return True
 
     def run_alignment_stats(self, sample, threads):
         sample_dir = self.genome.get_sample_path(sample.get_id())
         sample_bam = sample.get_sample_data("bam")
-        # samtools stats 
-        stats_cmd = ["samtools","stats","--threads",str(threads),sample_bam]
-        stats_output = os.path.join(sample_dir,sample.get_id()+".samtools_stats")
-        sample.add_command("samtools_stats_"+self.genome.get_id(),stats_cmd,"running")
+        # samtools stats
+        stats_cmd = ["samtools", "stats", "--threads", str(threads), sample_bam]
+        stats_output = os.path.join(sample_dir, sample.get_id() + ".samtools_stats")
+        sample.add_command(
+            "samtools_stats_" + self.genome.get_id(), stats_cmd, "running"
+        )
         try:
             # TODO: ENABLE
             print("Running command:\n{0}".format(" ".join(stats_cmd)))
-            with open(stats_output,"w") as so:
-                subprocess.check_call(stats_cmd,stdout=so)
-            sample.set_command_status("samtools_stats_"+self.genome.get_id(),"finished")
+            with open(stats_output, "w") as so:
+                subprocess.check_call(stats_cmd, stdout=so)
+            sample.set_command_status(
+                "samtools_stats_" + self.genome.get_id(), "finished"
+            )
         except Exception as e:
-            sys.stderr.write("Samtools stats encountered an error in Sample {0}:\ncheck error log file\n".format(sample.get_id()))
-            sample.set_command_status("samtools_stats_"+self.genome.get_id(),e)
-       
-        avg_len = self.get_average_read_length_per_file(stats_output) 
-        sample.add_sample_data('avg_read_length',avg_len) 
+            sys.stderr.write(
+                "Samtools stats encountered an error in Sample {0}:\ncheck error log file\n".format(
+                    sample.get_id()
+                )
+            )
+            sample.set_command_status("samtools_stats_" + self.genome.get_id(), e)
+
+        avg_len = self.get_average_read_length_per_file(stats_output)
+        sample.add_sample_data("avg_read_length", avg_len)
 
         # samstat
-        samstat_cmd = ["samstat",sample_bam]
-        sample.add_command("samstat_"+self.genome.get_id(),samstat_cmd,"running")
+        samstat_cmd = ["samstat", sample_bam]
+        sample.add_command("samstat_" + self.genome.get_id(), samstat_cmd, "running")
         try:
             print("Running command:\n{0}".format(" ".join(samstat_cmd)))
             # TODO: ENABLE
             subprocess.check_call(samstat_cmd)
-            sample.set_command_status("samstat_"+self.genome.get_id(),"finished")
+            sample.set_command_status("samstat_" + self.genome.get_id(), "finished")
         except Exception as e:
-            sys.stderr.write("Samstat encountered an error in Sample {0}:\ncheck error log file".format(sample.get_id()))
-            sample.set_command_status("samstat_"+self.genome.get_id(),e)
+            sys.stderr.write(
+                "Samstat encountered an error in Sample {0}:\ncheck error log file".format(
+                    sample.get_id()
+                )
+            )
+            sample.set_command_status("samstat_" + self.genome.get_id(), e)
 
-    #Reads the output from samtools stat and grabs the average read length value
-    def get_average_read_length_per_file(self,stats_file):
+    # Reads the output from samtools stat and grabs the average read length value
+    def get_average_read_length_per_file(self, stats_file):
         avg_len = 0
-        with open(stats_file,"r") as sf:
+        with open(stats_file, "r") as sf:
             for line in sf:
-                if "average length:" in line: 
+                if "average length:" in line:
                     line = line.strip().split()
                     avg_length = line[-1]
                     break
-        return avg_len 
+        return avg_len
 
     # TODO: incorporate checking the sample alignment results
-    def run_sample_alignment(self,sample,threads):
+    def run_sample_alignment(self, sample, threads):
         # TODO: here change sample_dir to the genome directory?
         #   - sample.get_path() to genome.get_sample_path(sample.get_path())
         # sample reads
-        sample_dir = sample.get_path()  
+        sample_dir = sample.get_path()
         reads = sample.get_reads_as_list()
         sampled_reads_list = []
         readNum = 1
         for r in reads:
-            sample_file = r.split(".") # TODO: change where this is output?
-            sample_file[len(sample_file)-1] = "sampled"
+            sample_file = r.split(".")  # TODO: change where this is output?
+            sample_file[len(sample_file) - 1] = "sampled"
             sample_file.append("fq")
             sample_file = ".".join(sample_file)
             sampled_reads_list.append(sample_file)
-            sample_cmd = ["seqtk","sample","-s","42",r,str(self.sampled_reads)]
-            sample.add_command("sample"+str(readNum),sample_cmd,"running")
-            print("Running command:\n{0}".format(" ".join(sample_cmd))) 
+            sample_cmd = ["seqtk", "sample", "-s", "42", r, str(self.sampled_reads)]
+            sample.add_command("sample" + str(readNum), sample_cmd, "running")
+            print("Running command:\n{0}".format(" ".join(sample_cmd)))
             try:
                 # TODO: ENABLE
-                with open(sample_file,"w") as so:
-                    subprocess.check_call(sample_cmd,stdout=so)
-                sample.set_command_status("sample"+str(readNum),"finished")
+                with open(sample_file, "w") as so:
+                    subprocess.check_call(sample_cmd, stdout=so)
+                sample.set_command_status("sample" + str(readNum), "finished")
             except Exception as e:
-                sys.stderr.write("Sampling encountered an error in Sample {0}:\ncheck error log file".format(sample.get_id()))   
-                sample.set_command_status("sample"+str(readNum),e)
+                sys.stderr.write(
+                    "Sampling encountered an error in Sample {0}:\ncheck error log file".format(
+                        sample.get_id()
+                    )
+                )
+                sample.set_command_status("sample" + str(readNum), e)
                 return False
             readNum = readNum + 1
         print("sampled reads list:\n{0}".format(sampled_reads_list))
-    
-        # align sampled reads        
+
+        # align sampled reads
         # TODO: enable for host
-        sampled_sam = os.path.join(sample_dir,sample.get_id()+"_sample.sam")
-        if self.genome.get_genome_type() == 'bacteria':
-            sample_align_cmd = ["bowtie2","-x",self.genome.get_genome_data("bowtie_prefix")]
+        sampled_sam = os.path.join(sample_dir, sample.get_id() + "_sample.sam")
+        if self.genome.get_genome_type() == "bacteria":
+            sample_align_cmd = [
+                "bowtie2",
+                "-x",
+                self.genome.get_genome_data("bowtie_prefix"),
+            ]
         else:
-            sample_align_cmd = ["hisat2","-x",self.genome.get_genome_data('hisat_prefix'),'--mp','1,0','--pen-noncansplice','20']
+            sample_align_cmd = [
+                "hisat2",
+                "-x",
+                self.genome.get_genome_data("hisat_prefix"),
+                "--mp",
+                "1,0",
+                "--pen-noncansplice",
+                "20",
+            ]
         if sample.get_type() == "paired":
-            sample_align_cmd += ["-1",sampled_reads_list[0],"-2",sampled_reads_list[1]]
+            sample_align_cmd += [
+                "-1",
+                sampled_reads_list[0],
+                "-2",
+                sampled_reads_list[1],
+            ]
         elif sample.sample_type == "single":
-            sample_align_cmd += ["-U",sampled_reads_list[0]]
-        sample_align_cmd += ["-S",sampled_sam,"-p",str(threads)] 
-        sample.add_command("sample_align",sample_align_cmd,"running") 
-        print("Running command:\n{0}".format(" ".join(sample_align_cmd))) 
+            sample_align_cmd += ["-U", sampled_reads_list[0]]
+        sample_align_cmd += ["-S", sampled_sam, "-p", str(threads)]
+        sample.add_command("sample_align", sample_align_cmd, "running")
+        print("Running command:\n{0}".format(" ".join(sample_align_cmd)))
         try:
             # TODO: ENABLE
             subprocess.check_call(sample_align_cmd)
-            sample.set_command_status("sample_align","finished")
+            sample.set_command_status("sample_align", "finished")
         except Exception as e:
-            sys.stderr.write("Sample-alignment encountered an error in Sample {0}:\ncheck error log file".format(sample.get_id()))
-            sample.set_command_status("sample_align",e)
+            sys.stderr.write(
+                "Sample-alignment encountered an error in Sample {0}:\ncheck error log file".format(
+                    sample.get_id()
+                )
+            )
+            sample.set_command_status("sample_align", e)
             return False
 
         # TODO: condition for assigning strandedness?
-        infer_cmd = ["infer_experiment.py","-i",sampled_sam,"-r",self.genome.get_genome_data("bed"),"-s",str(self.strand_reads)]
-        infer_file = os.path.join(sample_dir,sample.get_id()+"_strand.infer")
-        sample.add_command("infer_strand",infer_cmd,"running")
+        infer_cmd = [
+            "infer_experiment.py",
+            "-i",
+            sampled_sam,
+            "-r",
+            self.genome.get_genome_data("bed"),
+            "-s",
+            str(self.strand_reads),
+        ]
+        infer_file = os.path.join(sample_dir, sample.get_id() + "_strand.infer")
+        sample.add_command("infer_strand", infer_cmd, "running")
         print("Running command:\n{0}".format(" ".join(infer_cmd)))
         try:
             # TODO: ENABLE
-            with open(infer_file,"w") as o:
-                subprocess.check_call(infer_cmd,stdout=o) 
-            sample.set_command_status("infer_strand","finished")
-            sample.add_sample_data("infer_strand_file",infer_file)
-            strand = self.infer_strand_from_file(sample.get_sample_data("infer_strand_file"))
-            sample.add_sample_data("strand",strand)
+            with open(infer_file, "w") as o:
+                subprocess.check_call(infer_cmd, stdout=o)
+            sample.set_command_status("infer_strand", "finished")
+            sample.add_sample_data("infer_strand_file", infer_file)
+            strand = self.infer_strand_from_file(
+                sample.get_sample_data("infer_strand_file")
+            )
+            sample.add_sample_data("strand", strand)
         except Exception as e:
-            sys.stderr.write("Infer strand encountered an error in Sample {0}:\ncheck error log file".format(sample.get_id()))
-            sample.set_command_status("infer_strand",e)
+            sys.stderr.write(
+                "Infer strand encountered an error in Sample {0}:\ncheck error log file".format(
+                    sample.get_id()
+                )
+            )
+            sample.set_command_status("infer_strand", e)
             return False
-        
+
         for sampled_reads_file in sampled_reads_list:
             if os.path.exists(sampled_reads_file):
                 os.remove(sampled_reads_file)
         if os.path.exists(sampled_sam):
             os.remove(sampled_sam)
 
-    def convert_sam_to_bam(self,sam_file, threads):
-        bam_file = sam_file.replace(".sam",".bam")
+    def convert_sam_to_bam(self, sam_file, threads):
+        bam_file = sam_file.replace(".sam", ".bam")
         print("bam_file = {0}".format(bam_file))
-        sam_to_bam_cmd = "samtools view -Su " + sam_file + " | samtools sort -o - - -@ " + str(threads) + " > " + bam_file
+        sam_to_bam_cmd = (
+            "samtools view -Su "
+            + sam_file
+            + " | samtools sort -o - - -@ "
+            + str(threads)
+            + " > "
+            + bam_file
+        )
         try:
             print("Running command:\n{0}".format(sam_to_bam_cmd))
             # TODO: ENABLE
-            subprocess.check_call(sam_to_bam_cmd,shell=True)
+            subprocess.check_call(sam_to_bam_cmd, shell=True)
         except Exception as e:
             sys.stderr.write("Error in converting sam to bam file:\n{0}\n".format(e))
             return None
@@ -996,117 +1327,153 @@ class Alignment:
         try:
             print("Running command:\n{0}".format(index_cmd))
             # TODO: ENABLE
-            subprocess.check_call(index_cmd,shell=True)
+            subprocess.check_call(index_cmd, shell=True)
         except Exception as e:
             sys.stderr.write("Error indexing bam file:\n{0}\n".format(e))
             return None
         return bam_file
 
-    def infer_strand_from_file(self,infer_file):
+    def infer_strand_from_file(self, infer_file):
         strand = None
-        with open(infer_file,"r") as handle: 
-            for x in range(0,3):
+        with open(infer_file, "r") as handle:
+            for x in range(0, 3):
                 next(handle)
             undetermined = float(next(handle).split(":")[1].strip())
             rf_stranded = float(next(handle).split(":")[1].strip())
             fr_stranded = float(next(handle).split(":")[1].strip())
             if undetermined > fr_stranded and undetermined > rf_stranded:
                 strand = "undetermined"
-            elif abs(fr_stranded - rf_stranded) <= 0.1: #subjective threshold: should work in most cases
+            elif (
+                abs(fr_stranded - rf_stranded) <= 0.1
+            ):  # subjective threshold: should work in most cases
                 strand = "undetermined"
             else:
-                strand = "FR" if fr_stranded > rf_stranded else "RF"  
+                strand = "FR" if fr_stranded > rf_stranded else "RF"
         return strand
 
-class DiffExpImport:
 
+class DiffExpImport:
     genome = None
     recipe = None
 
     def __init__(self):
-        print('Creating differential expression import manager')
+        print("Creating differential expression import manager")
 
-    def set_genome(self,g):
+    def set_genome(self, g):
         self.genome = g
 
-    def set_recipe(self,r):
+    def set_recipe(self, r):
         self.recipe = r
 
-    def write_gmx_file(self,output_dir):    
-        print('writing gmx file')
-        contrast_file_list = self.genome.get_genome_data('contrast_file_list') 
+    def write_gmx_file(self, output_dir):
+        print("writing gmx file")
+        contrast_file_list = self.genome.get_genome_data("contrast_file_list")
         contrast_list = []
         gene_count_dict = {}
         gene_set = set()
         if contrast_file_list is None:
-            print('Skipping contrast file export; contrast_file_list is None')
+            print("Skipping contrast file export; contrast_file_list is None")
         else:
             for contrast_file in contrast_file_list:
-                contrast_name = os.path.basename(contrast_file).replace(".tsv","")
+                contrast_name = os.path.basename(contrast_file).replace(".tsv", "")
                 contrast_list.append(contrast_name)
                 gene_count_dict[contrast_name] = {}
-                with open(contrast_file,"r") as cf:
+                with open(contrast_file, "r") as cf:
                     next(cf)
                     for line in cf:
-                        gene,baseMean,log2FC,lfcSE,stat,pvalue,padj = line.strip().split("\t")
+                        (
+                            gene,
+                            baseMean,
+                            log2FC,
+                            lfcSE,
+                            stat,
+                            pvalue,
+                            padj,
+                        ) = line.strip().split("\t")
                         # strip 'gene-' from identifiers for host
-                        gene_set.add(gene.replace("gene-",""))
+                        gene_set.add(gene.replace("gene-", ""))
                         gene_count_dict[contrast_name][gene] = log2FC
-        gmx_output = os.path.join(output_dir,'gene_exp.gmx')
-        self.genome.add_genome_data('gmx',gmx_output)
+        gmx_output = os.path.join(output_dir, "gene_exp.gmx")
+        self.genome.add_genome_data("gmx", gmx_output)
         # TODO: rewrite this?
-        with open(gmx_output,'w') as o:
-            o.write("Gene_ID\t%s\n"%"\t".join(contrast_list))
+        with open(gmx_output, "w") as o:
+            o.write("Gene_ID\t%s\n" % "\t".join(contrast_list))
             for gene in gene_set:
                 o.write(gene)
                 for contrast in contrast_list:
                     if gene in gene_count_dict[contrast]:
-                        o.write("\t%s"%gene_count_dict[contrast][gene])
+                        o.write("\t%s" % gene_count_dict[contrast][gene])
                     else:
                         o.write("\t0")
                 o.write("\n")
 
-    def run_diff_exp_import(self,output_dir,map_args):
-        if self.recipe == 'HTSeq-DESeq' or self.recipe == 'Host': # create gmx file from DESeq2 results
-            self.write_gmx_file(output_dir) 
+    def run_diff_exp_import(self, output_dir, map_args):
+        if (
+            self.recipe == "HTSeq-DESeq" or self.recipe == "Host"
+        ):  # create gmx file from DESeq2 results
+            self.write_gmx_file(output_dir)
         # elst cufflinks, file should already exist
-        gmx_file = self.genome.get_genome_data('gmx') 
-        transform_script = 'expression_transform_bvbrc'
+        gmx_file = self.genome.get_genome_data("gmx")
+        transform_script = "expression_transform_bvbrc"
         if gmx_file is None:
-            sys.stderr.write('gmx_file is null, exiting differential expression import\n')
+            sys.stderr.write(
+                "gmx_file is null, exiting differential expression import\n"
+            )
             return False
         if os.path.exists(gmx_file):
-            experiment_path=os.path.join(output_dir, map_args.d)
-            print(f'experiment_path={experiment_path}')
-            subprocess.call(["mkdir","-p",experiment_path])
-            transform_params = {"output_path":experiment_path, "xfile":gmx_file, "xformat":"tsv",\
-                    "xsetup":"gene_matrix", "source_id_type":"patric_id",\
-                    "data_type":"Transcriptomics", "experiment_title":"RNA-Seq", "experiment_description":"RNA-Seq",\
-                    "organism":self.genome.get_id()}
+            experiment_path = os.path.join(output_dir, map_args.d)
+            print(f"experiment_path={experiment_path}")
+            subprocess.call(["mkdir", "-p", experiment_path])
+            transform_params = {
+                "output_path": experiment_path,
+                "xfile": gmx_file,
+                "xformat": "tsv",
+                "xsetup": "gene_matrix",
+                "source_id_type": "patric_id",
+                "data_type": "Transcriptomics",
+                "experiment_title": "RNA-Seq",
+                "experiment_description": "RNA-Seq",
+                "organism": self.genome.get_id(),
+            }
             diffexp_json = self.setup_diffexp_json()
-            params_file=os.path.join(output_dir, "diff_exp_params.json")
+            params_file = os.path.join(output_dir, "diff_exp_params.json")
             # TODO: incorporate check for sstring
-            with open(params_file, 'w') as params_handle:
+            with open(params_file, "w") as params_handle:
                 params_handle.write(json.dumps(transform_params))
-            convert_cmd=[transform_script, "--ufile", params_file, "--sstring",map_args.sstring, "--output_path",experiment_path,"--xfile",gmx_file]
-            print (" ".join(convert_cmd))
+            convert_cmd = [
+                transform_script,
+                "--ufile",
+                params_file,
+                "--sstring",
+                map_args.sstring,
+                "--output_path",
+                experiment_path,
+                "--xfile",
+                gmx_file,
+            ]
+            print(" ".join(convert_cmd))
             try:
-               subprocess.check_call(convert_cmd)
-            except(subprocess.CalledProcessError):
-               sys.stderr.write("Running differential expression import failed.\n")
-               #subprocess.call(["rm","-rf",experiment_path])
-               return
-            diffexp_obj_file=os.path.join(output_dir, os.path.basename(map_args.d).lstrip("."))
-            with open(diffexp_obj_file, 'w') as diffexp_job:
+                subprocess.check_call(convert_cmd)
+            except subprocess.CalledProcessError:
+                sys.stderr.write("Running differential expression import failed.\n")
+                # subprocess.call(["rm","-rf",experiment_path])
+                return
+            diffexp_obj_file = os.path.join(
+                output_dir, os.path.basename(map_args.d).lstrip(".")
+            )
+            with open(diffexp_obj_file, "w") as diffexp_job:
                 diffexp_job.write(json.dumps(diffexp_json))
             return True
         else:
-            sys.stderr.write('GMX file does not exist, exiting differential expression import')
+            sys.stderr.write(
+                "GMX file does not exist, exiting differential expression import"
+            )
             return False
-            
+
     def setup_diffexp_json(self):
-        #job template for differential expression object
-        diffexp_json = json.loads("""                    {
+        # job template for differential expression object
+        diffexp_json = json.loads(
+            """                    {
                         "app": {
                             "description": "Parses and transforms users differential expression data",
                             "id": "DifferentialExpression",
@@ -1174,31 +1541,35 @@ class DiffExpImport:
                         },
                         "start_time": ""
                     }
-        """)
+        """
+        )
         return diffexp_json
 
 
-# Preprocessing: fastqc, trimming, sampled alignment(alignment?), strandedness(alignment?)  
+# Preprocessing: fastqc, trimming, sampled alignment(alignment?), strandedness(alignment?)
 class Preprocess:
-    
-    def __init__(self):    
-        print("Creating Preprocess manager")            
+    def __init__(self):
+        print("Creating Preprocess manager")
 
-    # TODO: implement multithreaded? 
-    def run_fastqc(self, sample): 
+    # TODO: implement multithreaded?
+    def run_fastqc(self, sample):
         sample_dir = sample.get_path()
         reads = sample.get_reads_as_list()
-        fastqc_cmd = ["fastqc","--outdir",sample_dir]
+        fastqc_cmd = ["fastqc", "--outdir", sample_dir]
         fastqc_cmd += reads
-        sample.add_command("fastqc",fastqc_cmd,"running")  
-        print("Running command:\n {0}".format(" ".join(fastqc_cmd))) 
+        sample.add_command("fastqc", fastqc_cmd, "running")
+        print("Running command:\n {0}".format(" ".join(fastqc_cmd)))
         try:
             # TODO: ENABLE
             subprocess.check_call(fastqc_cmd)
-            sample.set_command_status("fastqc","finished")
+            sample.set_command_status("fastqc", "finished")
         except Exception as e:
-            sys.stderr.write("FastQC encountered an error in Sample {0}:\ncheck error log file".format(sample.get_id()))   
-            sample.set_command_status("fastqc",e)
+            sys.stderr.write(
+                "FastQC encountered an error in Sample {0}:\ncheck error log file".format(
+                    sample.get_id()
+                )
+            )
+            sample.set_command_status("fastqc", e)
             return False
 
     # runs trim_galore on samples
@@ -1208,42 +1579,45 @@ class Preprocess:
         sample_dir = sample.get_path()
         reads = sample.get_reads_as_list()
         trimmed_reads = []
-        trim_cmd = ["trim_galore","--output_dir",sample_dir,"--cores",str(threads)]
+        trim_cmd = ["trim_galore", "--output_dir", sample_dir, "--cores", str(threads)]
         if sample.get_type() == "paired":
-            #trimmed_reads.append(os.path.join(sample_dir,os.path.basename(reads[0]).split(".")[0]+"_val_1.fq.gz"))
-            #trimmed_reads.append(os.path.join(sample_dir,os.path.basename(reads[1]).split(".")[0]+"_val_2.fq.gz"))
+            # trimmed_reads.append(os.path.join(sample_dir,os.path.basename(reads[0]).split(".")[0]+"_val_1.fq.gz"))
+            # trimmed_reads.append(os.path.join(sample_dir,os.path.basename(reads[1]).split(".")[0]+"_val_2.fq.gz"))
             trim_cmd += ["--paired"]
-        #if sample.get_type() == "single":
+        # if sample.get_type() == "single":
         #    trimmed_reads.append(os.path.join(sample_dir,os.path.basename(reads[0]).split('.')[0]+"_trimmed.fq.gz"))
         trim_cmd += reads
-        sample.add_command("trim",trim_cmd,"running")
-        trim_galore_stderr = os.path.join(sample_dir,'trim_galore.stderr')
+        sample.add_command("trim", trim_cmd, "running")
+        trim_galore_stderr = os.path.join(sample_dir, "trim_galore.stderr")
         try:
             print("Running command:\n{0}".format(" ".join(trim_cmd)))
             # TODO: ENABLE
-            with open(trim_galore_stderr,'w') as err:
-                subprocess.check_call(trim_cmd,stderr=err)
-            sample.set_command_status("trim","finished")
-            if sample.get_type() == "paired": 
+            with open(trim_galore_stderr, "w") as err:
+                subprocess.check_call(trim_cmd, stderr=err)
+            sample.set_command_status("trim", "finished")
+            if sample.get_type() == "paired":
                 read_parts1 = os.path.basename(reads[0]).split(".")
                 read_parts2 = os.path.basename(reads[1]).split(".")
-                new_r1 = glob.glob(os.path.join(sample_dir,'*_val_1.*'))[0]
-                new_r2 = glob.glob(os.path.join(sample_dir,'*_val_2.*'))[0]
+                new_r1 = glob.glob(os.path.join(sample_dir, "*_val_1.*"))[0]
+                new_r2 = glob.glob(os.path.join(sample_dir, "*_val_2.*"))[0]
                 trimmed_reads.append(new_r1)
                 trimmed_reads.append(new_r2)
             else:
-                read_parts = os.path.basename(reads[0]).split('.')
-                new_r = glob.glob(os.path.join(sample_dir,'*_trimmed.*'))[0]
+                read_parts = os.path.basename(reads[0]).split(".")
+                new_r = glob.glob(os.path.join(sample_dir, "*_trimmed.*"))[0]
                 trimmed_reads.append(new_r)
             sample.set_reads_list(trimmed_reads)
-            for cutadapt_file in glob.glob('./*cutadapt.log'):
-                os.remove(cutadapt_file)  
+            for cutadapt_file in glob.glob("./*cutadapt.log"):
+                os.remove(cutadapt_file)
         except Exception as e:
-            sys.stderr.write("Trimming encountered an error in Sample {0}:\ncheck error log file".format(sample.get_id()))
-            sample.set_command_status("trim",e)
+            sys.stderr.write(
+                "Trimming encountered an error in Sample {0}:\ncheck error log file".format(
+                    sample.get_id()
+                )
+            )
+            sample.set_command_status("trim", e)
             return False
         # TODO: remove cutadapt log files: _cutadapt.log
-        for r in sample.get_reads_as_list(): 
+        for r in sample.get_reads_as_list():
             if not os.path.exists(r):
                 print("{0} does not exist".format(r))
-

--- a/lib/process.py
+++ b/lib/process.py
@@ -84,8 +84,7 @@ class DifferentialExpression:
     # TODO: don't let colons exist in the condition names on UI
     def run_deseq2(self, output_dir):
         contrast_list = self.comparisons.get_contrast_list()
-        gene_counts = self.genome.get_genome_data(
-            f"{self.genome.get_id()}_gene_counts")
+        gene_counts = self.genome.get_genome_data(f"{self.genome.get_id()}_gene_counts")
         genome_type = self.genome.get_genome_type()
         meta_file = self.genome.get_genome_data("sample_metadata_file")
 
@@ -286,9 +285,7 @@ class GenomeData:
                     "superclass_figure", superclass_figure + ".png"
                 )
         except Exception as e:
-            sys.stderr.write(
-                "Error creating superclass violin plots:\n{0}\n".format(e)
-                )
+            sys.stderr.write("Error creating superclass violin plots:\n{0}\n".format(e))
 
         try:
             pathway_figure = os.path.join(
@@ -309,9 +306,7 @@ class GenomeData:
                 # self.genome.add_genome_data('pathway_figure',pathway_figure+'.svg')
                 self.genome.add_genome_data("pathway_figure", pathway_figure + ".png")
         except Exception as e:
-            sys.stderr.write(
-                "Error creating pathway violin plots:\n{0}\n".format(e)
-                )
+            sys.stderr.write("Error creating pathway violin plots:\n{0}\n".format(e))
 
     def create_fpkm_figures(self, output_dir):
         superclass_mapping = self.genome.get_genome_data("superclass_mapping")
@@ -319,8 +314,7 @@ class GenomeData:
         genome_counts = self.genome.get_genome_data("fpkm")
         if genome_counts is None:
             sys.stderr.write(
-                "No fpkm's matrix in genome data: ",
-                "exiting create_fpkm_figures\n"
+                "No fpkm's matrix in genome data: ", "exiting create_fpkm_figures\n"
             )
             return False
         metadata = self.genome.get_genome_data("sample_metadata_file")
@@ -345,9 +339,7 @@ class GenomeData:
                     "superclass_figure", superclass_figure + ".png"
                 )
         except Exception as e:
-            sys.stderr.write(
-                "Error creating superclass violin plots:\n{0}\n".format(e)
-                )
+            sys.stderr.write("Error creating superclass violin plots:\n{0}\n".format(e))
         try:
             pathway_figure = os.path.join(
                 self.genome.get_genome_data("report_img_path"),
@@ -367,9 +359,7 @@ class GenomeData:
                 # self.genome.add_genome_data('pathway_figure',pathway_figure+'.svg')
                 self.genome.add_genome_data("pathway_figure", pathway_figure + ".png")
         except Exception as e:
-            sys.stderr.write(
-                "Error creating pathway violin plots:\n{0}\n".format(e)
-                )
+            sys.stderr.write("Error creating pathway violin plots:\n{0}\n".format(e))
 
     def run_pathway(self, output_dir, session):
         # pathway_df = getPathwayDataFrame([self.genome.get_id()], session)
@@ -685,7 +675,7 @@ class Quantify:
             sys.stderr.write(
                 "Error in rnaseqPrepDE.py: ",
                 "cannot generate genome counts or transcript counts file",
-                e
+                e,
             )
             sys.exit(-1)
 
@@ -765,7 +755,8 @@ class Quantify:
                 )
             if not os.path.exists(fpkm_file):
                 sys.stderr.write(
-                    f"Error running cuffnorm: {fpkm_file} does not exist\n")
+                    f"Error running cuffnorm: {fpkm_file} does not exist\n"
+                )
                 return -1
             attr_file = os.path.join(
                 output_dir,
@@ -956,8 +947,7 @@ class Quantify:
             if not os.path.exists(gtf_output) or True:
                 sample.add_command(
                     f"stringtie_merged_{self.genome.get_id()}",
-                    quant_cmd,
-                    "running"
+                    quant_cmd, "running"
                 )
                 print("Running command:\n{0}\n".format(" ".join(quant_cmd)))
                 try:
@@ -966,13 +956,17 @@ class Quantify:
                         "stringtie_merged_" + self.genome.get_id(), "finished"
                     )
                     sample.add_sample_data(
-                        self.genome.get_id() + "_merged_transcripts", gtf_output
+                        self.genome.get_id() + "_merged_transcripts",
+                        gtf_output
                     )
                     sample.add_sample_data(
-                        self.genome.get_id() + "_merged_gene_counts", gene_output
+                        self.genome.get_id() + "_merged_gene_counts",
+                        gene_output
                     )
                 except Exception as e:
-                    sys.stderr.write("Error running stringtie-merged:\n{0}\n".format(e))
+                    sys.stderr.write(
+                        "Error running stringtie-merged:\n{0}\n".format(e)
+                        )
                     sample.set_command_status(
                         "stringtie_merged_" + self.genome.get_id(), e
                     )
@@ -1086,9 +1080,7 @@ class Alignment:
         reads_list = sample.get_reads_as_list()
         sam_file = os.path.join(sample_dir, sample.get_id() + ".sam")
         if self.genome.get_genome_type() == "bacteria":
-            align_cmd = [
-                "bowtie2",
-                "-x", self.genome.get_genome_data("bowtie_prefix")]
+            align_cmd = ["bowtie2", "-x", self.genome.get_genome_data("bowtie_prefix")]
         else:
             align_cmd = [
                 "hisat2",
@@ -1104,11 +1096,7 @@ class Alignment:
         elif sample.sample_type == "single":
             align_cmd += ["-U", reads_list[0]]
         align_cmd += ["-S", sam_file, "-p", str(threads)]
-        sample.add_command(
-            f"align_{self.genome.get_id()}",
-            align_cmd,
-            "running"
-            )
+        sample.add_command(f"align_{self.genome.get_id()}", align_cmd, "running")
         align_output_file = sam_file.replace(".sam", ".align_stdout")
         print("Running command:\n{0}".format(" ".join(align_cmd)))
         try:
@@ -1124,15 +1112,12 @@ class Alignment:
                 self.genome.get_id() + "_align_stats", align_output_file
             )
             sample.set_alignment_status(True)
-            sample.set_command_status(
-                "align_" + self.genome.get_id(),
-                "finished"
-                )
+            sample.set_command_status("align_" + self.genome.get_id(), "finished")
         except Exception as e:
             sys.stderr.write(
                 "Sample-alignment encountered an error in Sample ",
-                f"{sample.get_id()}:\ncheck error log file\n"
-                )
+                f"{sample.get_id()}:\ncheck error log file\n",
+            )
             sample.set_command_status("align" + "_" + self.genome.get_id(), e)
             return False
 
@@ -1142,14 +1127,14 @@ class Alignment:
         else:
             sys.stderr.write(
                 "Bam file entry does not exist for Sample ",
-                f"{sample.get_id()}:\ncheck error log file\n"
+                f"{sample.get_id()}:\ncheck error log file\n",
             )
             return False
         if not os.path.exists(bam_file):
             sys.stderr.write(
                 "Bam file does not exist for Sample ",
                 str(sample.get_id()),
-                ":\ncheck error log file\n"
+                ":\ncheck error log file\n",
             )
             return False
         # remove sam file
@@ -1320,8 +1305,8 @@ class Alignment:
             sys.stderr.write(
                 "Sample-alignment encountered an error ",
                 f"in Sample {sample.get_id()}:",
-                "\ncheck error log file"
-                )
+                "\ncheck error log file",
+            )
             sample.set_command_status("sample_align", e)
             return False
 
@@ -1351,8 +1336,8 @@ class Alignment:
         except Exception as e:
             sys.stderr.write(
                 "Infer strand encountered an error in ",
-                f"Sample {sample.get_id()}:\ncheck error log file"
-                )
+                f"Sample {sample.get_id()}:\ncheck error log file",
+            )
             sample.set_command_status("infer_strand", e)
             return False
 
@@ -1378,9 +1363,7 @@ class Alignment:
             # TODO: ENABLE
             subprocess.check_call(sam_to_bam_cmd, shell=True)
         except Exception as e:
-            sys.stderr.write(
-                "Error in converting sam to bam file:\n{0}\n".format(e)
-                )
+            sys.stderr.write("Error in converting sam to bam file:\n{0}\n".format(e))
             return None
         index_cmd = "samtools index " + bam_file
         try:

--- a/lib/process.py
+++ b/lib/process.py
@@ -900,7 +900,7 @@ class Alignment:
             for line in sf:
                 if "average length:" in line: 
                     line = line.strip().split()
-                    avg_len = line[-1]
+                    avg_length = line[-1]
                     break
         return avg_len 
 

--- a/lib/process.py
+++ b/lib/process.py
@@ -1054,7 +1054,7 @@ class Quantify:
                     "Can't copy %s to %s: %s\n" % (sample_bam, bam_tmp, err)
                 )
 
-            if bam_to_use == None:
+            if bam_to_use is None:
                 try:
                     tmpfd, bam_tmp = tempfile.mkstemp(prefix="CUFFL.", dir=".")
                     os.close(tmpfd)
@@ -1069,7 +1069,7 @@ class Quantify:
                         "Can't copy %s to %s: %s\n" % (sample_bam, bam_tmp, err)
                     )
 
-            if bam_to_use == None:
+            if bam_to_use is None:
                 sys.stderr.write("Can't copy %s to tmp space\n" % (sample_bam))
                 bam_to_use = sample_bam
                 bam_tmp = None
@@ -1091,7 +1091,7 @@ class Quantify:
                 )
                 return False
 
-            if bam_tmp != None:
+            if bam_tmp is not None:
                 sys.stderr.write("remove temp %s\n" % (bam_tmp))
                 os.unlink(bam_tmp)
         return True

--- a/lib/report.py
+++ b/lib/report.py
@@ -3,61 +3,81 @@
 # library modules
 import subprocess, sys, os
 
-class ReportManager:
 
+class ReportManager:
     def __init__(self):
         print("Creating ReportManger")
 
-    def run_multiqc(self,output_path):
+    def run_multiqc(self, output_path):
         debug_multiqc = False
         remove_data_dir = True
         force_overwrite = True
-        report_name = os.path.join(output_path,'multiqc_report')
-        multiqc_cmd = ["multiqc","--flat","-o",".","-n",report_name,"-t","simple","."]
+        report_name = os.path.join(output_path, "multiqc_report")
+        multiqc_cmd = [
+            "multiqc",
+            "--flat",
+            "-o",
+            ".",
+            "-n",
+            report_name,
+            "-t",
+            "simple",
+            ".",
+        ]
         if remove_data_dir:
             multiqc_cmd += ["--no-data-dir"]
         if force_overwrite:
             multiqc_cmd += ["-f"]
         if debug_multiqc:
-            multiqc_cmd += ["--lint"] 
+            multiqc_cmd += ["--lint"]
         # ignore files with certain extensions
-        multiqc_cmd += ["--ignore","\"*deseq2.tsv\"","--ignore","\"*gmx\""]
+        multiqc_cmd += ["--ignore", '"*deseq2.tsv"', "--ignore", '"*gmx"']
         try:
-            print(' '.join(multiqc_cmd))
-            subprocess.check_call(' '.join(multiqc_cmd),shell=True)
+            print(" ".join(multiqc_cmd))
+            subprocess.check_call(" ".join(multiqc_cmd), shell=True)
         except Exception as e:
-            sys.stderr.write('Error running multiqc:\n{0}'.format(e)) 
+            sys.stderr.write("Error running multiqc:\n{0}".format(e))
             return -1
 
-    def create_report(self, genome, output_dir, experiment_dict, report_stats, workspace_dir, diffexp_flag):
+    def create_report(
+        self,
+        genome,
+        output_dir,
+        experiment_dict,
+        report_stats,
+        workspace_dir,
+        diffexp_flag,
+    ):
         report_lines = []
-        genome_name = genome.get_genome_name() 
+        genome_name = genome.get_genome_name()
         report_html_header = self.create_html_header(genome_name)
         report_lines.append(report_html_header)
-        report_lines.append('<body>')
+        report_lines.append("<body>")
 
-        report_header = "<header>\n<div class=\"report-info pull-right\">\n<span>Report Date:</span>{0}<br>\n<span>Organism:</span>{1}\n</div>\n</header>".format('DATE',genome.get_genome_name())
+        report_header = '<header>\n<div class="report-info pull-right">\n<span>Report Date:</span>{0}<br>\n<span>Organism:</span>{1}\n</div>\n</header>'.format(
+            "DATE", genome.get_genome_name()
+        )
         report_lines.append(report_header)
 
         # Intro: which genome, pipeline, number of samples, conditions, and if differential expression was performed
-        report_lines.append('<section>\n<h2>Summary</h2>')
-        report_summary = self.create_summary(report_stats,genome)
+        report_lines.append("<section>\n<h2>Summary</h2>")
+        report_summary = self.create_summary(report_stats, genome)
         report_lines.append(report_summary)
-        report_lines.append('</section>')
+        report_lines.append("</section>")
 
         # Link to multiqc report for basic sample summary statistics
-        report_lines.append('<section>\n<h2>MultiQC Report Link</h2>')
+        report_lines.append("<section>\n<h2>MultiQC Report Link</h2>")
         report_lines.append(self.create_multiqc_link(workspace_dir))
-        report_lines.append('</section>')
+        report_lines.append("</section>")
 
         # Sample IDs and their conditions that have issues
-        report_lines.append('<section>\n<h2>Sample Summary Table</h2>')
-        report_sample_table = self.create_sample_table(experiment_dict,genome)
+        report_lines.append("<section>\n<h2>Sample Summary Table</h2>")
+        report_sample_table = self.create_sample_table(experiment_dict, genome)
         report_lines.append(report_sample_table)
-        report_lines.append('</section>')
+        report_lines.append("</section>")
 
         # Any figures in report_images
-        #if genome.get_genome_type() == 'bacteria':
+        # if genome.get_genome_type() == 'bacteria':
         #    report_lines.append('<section>\n<h2>Subsystems Distribution</h2>')
         #    report_subsystems = self.get_subsystem_figure(genome)
         #    report_lines.append(report_subsystems)
@@ -69,11 +89,11 @@ class ReportManager:
 
         # differential expression section if turned on
         # TODO: add when svg API issue is fixed
-        #if diffexp_flag:
+        # if diffexp_flag:
 
         # check for error output
         error_section_flag = False
-        bad_alignment_flag = False 
+        bad_alignment_flag = False
         for condition in experiment_dict:
             for sample in experiment_dict[condition].get_sample_list():
                 # check each of the error flags
@@ -84,219 +104,233 @@ class ReportManager:
                 if not alignment_check:
                     bad_alignment_flag = True
         if bad_alignment_flag:
-            report_lines.append('<section>\n<h2>Alignment Results</h2>')
-            align_lines = self.create_bad_align_section(experiment_dict,genome)
+            report_lines.append("<section>\n<h2>Alignment Results</h2>")
+            align_lines = self.create_bad_align_section(experiment_dict, genome)
             report_lines.append(align_lines)
-            report_lines.append('</section>')
+            report_lines.append("</section>")
         if error_section_flag:
-            report_lines.append('<section>\n<h2>Errors</h2>')
-            error_lines = self.create_error_section(experiment_dict,genome)
+            report_lines.append("<section>\n<h2>Errors</h2>")
+            error_lines = self.create_error_section(experiment_dict, genome)
             report_lines.append(error_lines)
-            report_lines.append('</section>')
+            report_lines.append("</section>")
 
         # references
-        report_lines.append('<section>\n<h2>References</h2>')
+        report_lines.append("<section>\n<h2>References</h2>")
         reference_lines = self.create_references()
         report_lines.append(reference_lines)
-        report_lines.append('</section>')
+        report_lines.append("</section>")
 
-        report_lines.append('</body>')
-        report_lines.append('</html>')
-        report_html = '\n'.join(report_lines)
-        output_report = os.path.join(output_dir,'bvbrc_rnaseq_report.html')
-        with open(output_report,'w') as o:
+        report_lines.append("</body>")
+        report_lines.append("</html>")
+        report_html = "\n".join(report_lines)
+        output_report = os.path.join(output_dir, "bvbrc_rnaseq_report.html")
+        with open(output_report, "w") as o:
             o.write(report_html)
 
     def create_summary(self, report_stats, genome):
-        summary_str = f"The BV-BRC RNASeq service was run using the {report_stats['recipe']} pipeline with {report_stats['num_samples']} samples and {report_stats['num_conditions']} conditions." 
+        summary_str = f"The BV-BRC RNASeq service was run using the {report_stats['recipe']} pipeline with {report_stats['num_samples']} samples and {report_stats['num_conditions']} conditions."
         summary_str += f" The reference genome used was {genome.get_genome_name().replace('_',' ')} ({genome.get_id()})."
         return summary_str
 
     def create_multiqc_link(self, workspace_path):
-        #url_base = "https://www.bv-brc.org/workspace"
-        url_base = ''
-        if workspace_path[-1] != '/':
-            workspace_path += '/'
-        url = url_base + workspace_path + 'multiqc_report.html'
-        link_text = f'<a href=\"multiqc_report.html\" target=\"_parent\">multiqc report link</a>'
-        return link_text 
+        # url_base = "https://www.bv-brc.org/workspace"
+        url_base = ""
+        if workspace_path[-1] != "/":
+            workspace_path += "/"
+        url = url_base + workspace_path + "multiqc_report.html"
+        link_text = (
+            f'<a href="multiqc_report.html" target="_parent">multiqc report link</a>'
+        )
+        return link_text
 
     def get_subsystem_figure(self, genome):
-        subsystem_figure_path = genome.get_genome_data('superclass_figure') 
+        subsystem_figure_path = genome.get_genome_data("superclass_figure")
         if subsystem_figure_path and os.path.exists(subsystem_figure_path):
-            if subsystem_figure_path.endswith('.png'):
-                return '<p>Error: Png file for subsystems</p>'
+            if subsystem_figure_path.endswith(".png"):
+                return "<p>Error: Png file for subsystems</p>"
             try:
-                with open(subsystem_figure_path,'r') as sfp: 
+                with open(subsystem_figure_path, "r") as sfp:
                     subsystem_figure = sfp.read()
-                #subsystem_figure = f'<img src = \"report_images/{genome.get_id()}_Superclass_Distribution.svg\"'
+                # subsystem_figure = f'<img src = \"report_images/{genome.get_id()}_Superclass_Distribution.svg\"'
                 return subsystem_figure
             except Exception as e:
-                sys.stderr.write(f'Error reading file: {subsystem_figure_path}\n')
-                return '<p>Error: no subsystem figure found</p>'
+                sys.stderr.write(f"Error reading file: {subsystem_figure_path}\n")
+                return "<p>Error: no subsystem figure found</p>"
         else:
-            return '<p>Error: no subsystem figure found</p>'
+            return "<p>Error: no subsystem figure found</p>"
 
     def get_pathway_figure(self, genome):
-        pathway_figure_path = genome.get_genome_data('pathway_figure') 
+        pathway_figure_path = genome.get_genome_data("pathway_figure")
         if pathway_figure_path and os.path.exists(pathway_figure_path):
-            if pathway_figure_path.endswith('.png'):
-                return '<p>Error: Png file pathways</p>'
+            if pathway_figure_path.endswith(".png"):
+                return "<p>Error: Png file pathways</p>"
             try:
-                with open(pathway_figure_path,'r') as pfp: 
+                with open(pathway_figure_path, "r") as pfp:
                     pathway_figure = pfp.read()
-                #pathway_figure = f'<img src = \"report_images/{genome.get_id()}_Pathway_Distribution.svg\"'
+                # pathway_figure = f'<img src = \"report_images/{genome.get_id()}_Pathway_Distribution.svg\"'
                 return pathway_figure
             except Exception as e:
-                sys.stderr.write(f'Error reading file: {pathway_figure_path}\n')
-                return '<p>Error: no pathway figure found</p>'
+                sys.stderr.write(f"Error reading file: {pathway_figure_path}\n")
+                return "<p>Error: no pathway figure found</p>"
         else:
-            return '<p>Error: no pathway figure found</p>'
-    
-    def create_sample_table(self,experiment_dict,genome): 
+            return "<p>Error: no pathway figure found</p>"
+
+    def create_sample_table(self, experiment_dict, genome):
         table_list = []
-        table_list.append("<table class=\"sm-table kv-table center\">")
-        table_list.append("<thead class=\"table-header\">")
-        table_list.append("<tr>\n<th colspan=\"4\">\n<table-num>Table 1.</table-num>Sample Details\n</th>\n</tr>\n</thead>")
+        table_list.append('<table class="sm-table kv-table center">')
+        table_list.append('<thead class="table-header">')
+        table_list.append(
+            '<tr>\n<th colspan="4">\n<table-num>Table 1.</table-num>Sample Details\n</th>\n</tr>\n</thead>'
+        )
         table_list.append("<tbody>")
-        #table_list.append("<tr>\n<td>Condition</td>\n<td>Sample</td>\n<td>Quality</td>\n<td>Alignment</td>\n</tr>")
-        table_list.append("<tr>\n<td>Condition</td>\n<td>Sample</td>\n<td>Alignment</td>\n</tr>")
+        # table_list.append("<tr>\n<td>Condition</td>\n<td>Sample</td>\n<td>Quality</td>\n<td>Alignment</td>\n</tr>")
+        table_list.append(
+            "<tr>\n<td>Condition</td>\n<td>Sample</td>\n<td>Alignment</td>\n</tr>"
+        )
         # TODO: store stats in sample objects
         for condition in experiment_dict:
-            if condition == 'no_condition':
-                condition_str = 'None'
+            if condition == "no_condition":
+                condition_str = "None"
             else:
                 condition_str = condition
             for sample in experiment_dict[condition].get_sample_list():
-                #new_line = f"<tr>\n<td>{condition}</td>\n<td>{sample.get_id()}</td>\n<td>QUALITY</td>\n<td>ALIGNMENT</td>"
-                align_file = sample.get_sample_data(genome.get_id()+'_align_stats')
-                align_str = 'ALIGNMENT'
+                # new_line = f"<tr>\n<td>{condition}</td>\n<td>{sample.get_id()}</td>\n<td>QUALITY</td>\n<td>ALIGNMENT</td>"
+                align_file = sample.get_sample_data(genome.get_id() + "_align_stats")
+                align_str = "ALIGNMENT"
                 if align_file and os.path.exists(align_file):
                     if sample.get_alignment_status():
-                        with open(align_file,'r') as af:
+                        with open(align_file, "r") as af:
                             align_text = af.readlines()
-                            align_str = align_text[-1].split(' ')[0]
+                            align_str = align_text[-1].split(" ")[0]
                     else:
-                        align_str = 'Error during alignment'
+                        align_str = "Error during alignment"
                 else:
-                    align_str = 'Error: no alignment stats'
+                    align_str = "Error: no alignment stats"
                 new_line = f"<tr>\n<td>{condition_str}</td>\n<td>{sample.get_id()}</td>\n<td>{align_str}</td>"
                 table_list.append(new_line)
         table_list.append("</tbody>")
-        table_list.append('</table>')
-        return '\n'.join(table_list)
+        table_list.append("</table>")
+        return "\n".join(table_list)
 
-    def create_error_section(self,experiment_dict,genome):
+    def create_error_section(self, experiment_dict, genome):
         error_list = []
-        # alignment errors 
-        error_list.append('<h2>Alignment Errors</h2>')
+        # alignment errors
+        error_list.append("<h2>Alignment Errors</h2>")
         for condition in experiment_dict:
             for sample in experiment_dict[condition].get_sample_list():
                 if not sample.get_alignment_status():
-                    error_list.append(f'<h1>Alignment Error for Sample {sample.get_id()}</h1>') 
-                    align_file = sample.get_sample_data(genome.get_id()+'_align_stats') 
-                    error_list.append('<p>')
+                    error_list.append(
+                        f"<h1>Alignment Error for Sample {sample.get_id()}</h1>"
+                    )
+                    align_file = sample.get_sample_data(
+                        genome.get_id() + "_align_stats"
+                    )
+                    error_list.append("<p>")
                     if os.path.exists(align_file):
-                        with open(align_file,'r') as af:
+                        with open(align_file, "r") as af:
                             align_text = af.readlines()
-                            #error_list.append('\n'.join(align_text))
+                            # error_list.append('\n'.join(align_text))
                         for line in align_text:
                             error_list.append(line)
-                            error_list.append('<br>')
+                            error_list.append("<br>")
                     else:
-                        error_list.append('Error, alignment stats file doesnt exist')
-                    error_list.append('</p>')
-        return '\n'.join(error_list)
+                        error_list.append("Error, alignment stats file doesnt exist")
+                    error_list.append("</p>")
+        return "\n".join(error_list)
 
-    def create_bad_align_section(self,experiment_dict,genome):
+    def create_bad_align_section(self, experiment_dict, genome):
         align_list = []
-        align_list.append('<h2>Alignment Results')
+        align_list.append("<h2>Alignment Results")
         for condition in experiment_dict:
             for sample in experiment_dict[condition].get_sample_list():
                 if not sample.get_alignment_check():
-                    align_list.append(f"<h1>{sample.get_id()} FAILS the alignment check</h1>")
+                    align_list.append(
+                        f"<h1>{sample.get_id()} FAILS the alignment check</h1>"
+                    )
                 else:
-                    align_list.append(f"<h1>{sample.get_id()} PASSES the alignment check</h1>")
-                align_file = sample.get_sample_data(genome.get_id()+'_align_stats')
-                align_list.append('<p>')
+                    align_list.append(
+                        f"<h1>{sample.get_id()} PASSES the alignment check</h1>"
+                    )
+                align_file = sample.get_sample_data(genome.get_id() + "_align_stats")
+                align_list.append("<p>")
                 if os.path.exists(align_file):
-                    with open(align_file,'r') as af:
+                    with open(align_file, "r") as af:
                         align_text = af.readlines()
                         for line in align_text:
                             align_list.append(line)
-                            align_list.append('<br>')
-                        #align_list.append('\n'.join(align_text))
+                            align_list.append("<br>")
+                        # align_list.append('\n'.join(align_text))
                 else:
-                    align_list.append('Error, alignment stats file doesnt exist')
-                align_list.append('</p>')
-        return '\n'.join(align_list)
+                    align_list.append("Error, alignment stats file doesnt exist")
+                align_list.append("</p>")
+        return "\n".join(align_list)
 
     def create_references(self):
         reference_list = []
-        reference_list.append('<ol>') 
+        reference_list.append("<ol>")
         # bvbrc
         bvbrc_ref = "Introducing the Bacterial and Viral Bioinformatics Resource Center (BV-BRC): a resource combining PATRIC, IRD and ViPR. \
                     Olson RD, Assaf R, Brettin T, Conrad N, Cucinell C, Davis JJ, Dempsey DM, Dickerman A, Dietrich EM, Kenyon RW, Kuscuoglu M, \
                     Lefkowitz EJ, Lu J, Machi D, Macken C, Mao C, Niewiadomska A, Nguyen M, Olsen GJ, Overbeek JC, Parrello B, Parrello V, Porter JS, \
                     Pusch GD, Shukla M, Singh I, Stewart L, Tan G, Thomas C, VanOeffelen M, Vonstein V, Wallace ZS, Warren AS, Wattam AR, Xia F, Yoo H, \
                     Zhang Y, Zmasek CM, Scheuermann RH, Stevens RL. Nucleic Acids Res. 2022 Nov 9:gkac1003. doi: 10.1093/nar/gkac1003. PMID: 36350631"
-        reference_list.append('<li>' + bvbrc_ref + '</li>')
+        reference_list.append("<li>" + bvbrc_ref + "</li>")
         # multiqc
         multiqc_ref = "MultiQC: Summarize analysis results for multiple tools and samples in a single report. Philip Ewels, Måns Magnusson, Sverker Lundin \
                         and Max Käller. Bioinformatics (2016) doi: 10.1093/bioinformatics/btw354 PMID: 27312411 "
-        reference_list.append('<li>' + multiqc_ref + '</li>')
+        reference_list.append("<li>" + multiqc_ref + "</li>")
         # fastqc
         fastqc_ref = "Andrews, S. (2010). FastQC:  A Quality Control Tool for High Throughput Sequence Data [Online]. Available online at: http://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
-        reference_list.append('<li>' + fastqc_ref + '</li>')
+        reference_list.append("<li>" + fastqc_ref + "</li>")
         # trimgalore
         trimgalore_ref = "FelixKrueger. (n.d.). Felixkrueger/Trimgalore: A wrapper around Cutadapt and FASTQC to consistently apply adapter and quality \
                         trimming to FASTQ files, with extra functionality for RRBS Data. GitHub. https://github.com/FelixKrueger/TrimGalore"
-        reference_list.append('<li>' + trimgalore_ref + '</li>')
+        reference_list.append("<li>" + trimgalore_ref + "</li>")
         # seqtk
         seqtk_ref = "lh3. (n.d.). Lh3/SEQTK: Toolkit for processing sequences in FASTA/Q Formats. GitHub. https://github.com/lh3/seqtk"
         # samtools
         samtools_ref = "Heng Li, Bob Handsaker, Alec Wysoker, Tim Fennell, Jue Ruan, Nils Homer, Gabor Marth, Goncalo Abecasis, Richard Durbin, \
                         1000 Genome Project Data Processing Subgroup, The Sequence Alignment/Map format and SAMtools, Bioinformatics, Volume 25, \
                         Issue 16, 15 August 2009, Pages 2078–2079, https://doi.org/10.1093/bioinformatics/btp352"
-        reference_list.append('<li>' + samtools_ref + '</li>')
+        reference_list.append("<li>" + samtools_ref + "</li>")
         # bowtie/hisat
         bowtie_ref = "Langmead B, Salzberg SL. Fast gapped-read alignment with Bowtie 2. Nat Methods. 2012 Mar 4;9(4):357-9. doi: 10.1038/nmeth.1923. PMID: 22388286; PMCID: PMC3322381."
         hisat_ref = "Kim, D., Paggi, J.M., Park, C. et al. Graph-based genome alignment and genotyping with HISAT2 and HISAT-genotype. Nat Biotechnol 37, 907–915 (2019). https://doi.org/10.1038/s41587-019-0201-4"
-        reference_list.append('<li>' + bowtie_ref + '</li>')
-        reference_list.append('<li>' + hisat_ref + '</li>')
+        reference_list.append("<li>" + bowtie_ref + "</li>")
+        reference_list.append("<li>" + hisat_ref + "</li>")
         # stringtie
         stringtie_ref = "Pertea M, Pertea GM, Antonescu CM, Chang TC, Mendell JT, Salzberg SL. StringTie enables improved reconstruction of a transcriptome from RNA-seq reads. \
                         Nat Biotechnol. 2015 Mar;33(3):290-5. doi: 10.1038/nbt.3122. Epub 2015 Feb 18. PMID: 25690850; PMCID: PMC4643835."
-        reference_list.append('<li>' + stringtie_ref + '</li>')
+        reference_list.append("<li>" + stringtie_ref + "</li>")
         # htseq
         htseq_ref = "Anders S, Pyl PT, Huber W. HTSeq--a Python framework to work with high-throughput sequencing data. Bioinformatics. \
                     2015 Jan 15;31(2):166-9. doi: 10.1093/bioinformatics/btu638. Epub 2014 Sep 25. PMID: 25260700; PMCID: PMC4287950."
-        reference_list.append('<li>' + htseq_ref + '</li>')
+        reference_list.append("<li>" + htseq_ref + "</li>")
         # tpmcalculator
         tpmcalculator_ref = "Roberto Vera Alvarez, Lorinc Sandor Pongor, Leonardo Mariño-Ramírez, David Landsman, TPMCalculator: \
                             one-step software to quantify mRNA abundance of genomic features, Bioinformatics, Volume 35, Issue 11, \
                             1 June 2019, Pages 1960–1962, https://doi.org/10.1093/bioinformatics/bty896"
-        reference_list.append('<li>' + tpmcalculator_ref + '</li>')
+        reference_list.append("<li>" + tpmcalculator_ref + "</li>")
         # rseqc
         rseqc_ref = "Wang L, Wang S, Li W. RSeQC: quality control of RNA-seq experiments. Bioinformatics. 2012 Aug 15;28(16):2184-5. doi: 10.1093/bioinformatics/bts356. Epub 2012 Jun 27. PMID: 22743226."
-        reference_list.append('<li>' + rseqc_ref + '</li>')
+        reference_list.append("<li>" + rseqc_ref + "</li>")
         # deseq2
         deseq_ref = "Love MI, Huber W, Anders S (2014). “Moderated estimation of fold change and dispersion for RNA-seq data with DESeq2.” Genome Biology, 15, 550. doi: 10.1186/s13059-014-0550-8. "
-        reference_list.append('<li>' + deseq_ref + '</li>')
+        reference_list.append("<li>" + deseq_ref + "</li>")
         # enhanced volcano
         ev_ref = "Blighe K, Rana S, Lewis M (2022). EnhancedVolcano: Publication-ready volcano plots with enhanced colouring and labeling. R package version 1.16.0, https://github.com/kevinblighe/EnhancedVolcano. "
-        reference_list.append('<li>' + ev_ref + '</li>')
+        reference_list.append("<li>" + ev_ref + "</li>")
         # ggplot
         ggplot_ref = "Wickham H (2016). ggplot2: Elegant Graphics for Data Analysis. Springer-Verlag New York. ISBN 978-3-319-24277-4, https://ggplot2.tidyverse.org. "
-        reference_list.append('<li>' + ggplot_ref + '</li>')
+        reference_list.append("<li>" + ggplot_ref + "</li>")
         # reference_list.append('<li>' + '' + '</li>')
-        reference_list.append('</ol>') 
-        return '\n'.join(reference_list)
+        reference_list.append("</ol>")
+        return "\n".join(reference_list)
 
-    def create_html_header(self,genome_name):
+    def create_html_header(self, genome_name):
         header = "<!DOCTYPE html><html><head>\n"
         header += "<title>BV-BRC RNASeq Report | {0}</title>\n".format(genome_name)
-        header += "<link href=\"https://fonts.googleapis.com/css?family=Work+Sans:300,400,500,600,700,800,900\" rel=\"stylesheet\">\n"
+        header += '<link href="https://fonts.googleapis.com/css?family=Work+Sans:300,400,500,600,700,800,900" rel="stylesheet">\n'
         header += """
             <style>
                 body {

--- a/lib/report.py
+++ b/lib/report.py
@@ -138,9 +138,7 @@ class ReportManager:
         if workspace_path[-1] != "/":
             workspace_path += "/"
         url = url_base + workspace_path + "multiqc_report.html"
-        link_text = (
-            f'<a href="multiqc_report.html" target="_parent">multiqc report link</a>'
-        )
+        link_text = f'<a href="multiqc_report.html" target="_parent">multiqc report link</a>'
         return link_text
 
     def get_subsystem_figure(self, genome):
@@ -154,7 +152,9 @@ class ReportManager:
                 # subsystem_figure = f'<img src = \"report_images/{genome.get_id()}_Superclass_Distribution.svg\"'
                 return subsystem_figure
             except Exception as e:
-                sys.stderr.write(f"Error reading file: {subsystem_figure_path}\n")
+                sys.stderr.write(
+                    f"Error reading file: {subsystem_figure_path}\n"
+                )
                 return "<p>Error: no subsystem figure found</p>"
         else:
             return "<p>Error: no subsystem figure found</p>"
@@ -195,7 +195,9 @@ class ReportManager:
                 condition_str = condition
             for sample in experiment_dict[condition].get_sample_list():
                 # new_line = f"<tr>\n<td>{condition}</td>\n<td>{sample.get_id()}</td>\n<td>QUALITY</td>\n<td>ALIGNMENT</td>"
-                align_file = sample.get_sample_data(genome.get_id() + "_align_stats")
+                align_file = sample.get_sample_data(
+                    genome.get_id() + "_align_stats"
+                )
                 align_str = "ALIGNMENT"
                 if align_file and os.path.exists(align_file):
                     if sample.get_alignment_status():
@@ -234,7 +236,9 @@ class ReportManager:
                             error_list.append(line)
                             error_list.append("<br>")
                     else:
-                        error_list.append("Error, alignment stats file doesnt exist")
+                        error_list.append(
+                            "Error, alignment stats file doesnt exist"
+                        )
                     error_list.append("</p>")
         return "\n".join(error_list)
 
@@ -251,7 +255,9 @@ class ReportManager:
                     align_list.append(
                         f"<h1>{sample.get_id()} PASSES the alignment check</h1>"
                     )
-                align_file = sample.get_sample_data(genome.get_id() + "_align_stats")
+                align_file = sample.get_sample_data(
+                    genome.get_id() + "_align_stats"
+                )
                 align_list.append("<p>")
                 if os.path.exists(align_file):
                     with open(align_file, "r") as af:
@@ -261,7 +267,9 @@ class ReportManager:
                             align_list.append("<br>")
                         # align_list.append('\n'.join(align_text))
                 else:
-                    align_list.append("Error, alignment stats file doesnt exist")
+                    align_list.append(
+                        "Error, alignment stats file doesnt exist"
+                    )
                 align_list.append("</p>")
         return "\n".join(align_list)
 
@@ -329,7 +337,9 @@ class ReportManager:
 
     def create_html_header(self, genome_name):
         header = "<!DOCTYPE html><html><head>\n"
-        header += "<title>BV-BRC RNASeq Report | {0}</title>\n".format(genome_name)
+        header += "<title>BV-BRC RNASeq Report | {0}</title>\n".format(
+            genome_name
+        )
         header += '<link href="https://fonts.googleapis.com/css?family=Work+Sans:300,400,500,600,700,800,900" rel="stylesheet">\n'
         header += """
             <style>

--- a/lib/report.py
+++ b/lib/report.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python3
 
 # library modules
-import subprocess, sys, os
+import subprocess
+import sys
+import os
 
 
 class ReportManager:
@@ -138,7 +140,7 @@ class ReportManager:
         if workspace_path[-1] != "/":
             workspace_path += "/"
         url = url_base + workspace_path + "multiqc_report.html"
-        link_text = f'<a href="multiqc_report.html" target="_parent">multiqc report link</a>'
+        link_text = '<a href="multiqc_report.html" target="_parent">multiqc report link</a>'
         return link_text
 
     def get_subsystem_figure(self, genome):

--- a/scripts/expression_transform_bvbrc.py
+++ b/scripts/expression_transform_bvbrc.py
@@ -13,17 +13,18 @@ from scipy import stats
 from itertools import islice
 from bvbrc_api import authenticateByEnv
 
-#requires 2.7.9 or greater to deal with https comodo intermediate certs
+# requires 2.7.9 or greater to deal with https comodo intermediate certs
 if sys.version_info < (2, 7):
-        raise "must use python 2.7 or greater"
+    raise "must use python 2.7 or greater"
 
-#stamp out annoying warnings that are beyond control
+# stamp out annoying warnings that are beyond control
 import warnings
-warnings.simplefilter(action = "ignore", category = FutureWarning)
+
+warnings.simplefilter(action="ignore", category=FutureWarning)
 pd.options.mode.chained_assignment = None
 
-#Input
-#1. metadata in json with the following:
+# Input
+# 1. metadata in json with the following:
 
 """
 {xformat:"csv || tsv || xls ||  xlsx",
@@ -37,457 +38,605 @@ pmid: "user_input",
 output_path: "path",
 "metadata_format":"csv || tsv || xls ||  xlsx"}
 """
-#2. server info for the data api
+# 2. server info for the data api
 """
 {"data_api":"url"}
 """
 
-#Sample Output
-#experiment.json
-#{"origFileName":"filename","geneMapped":4886,"samples":8,"geneTotal":4985,"cdate":"2013-01-28 13:40:47","desc":"user input","organism":"some org","owner":"user name","title":"user input","pmid":"user input","expid":"whatever","collectionType":"ExpressionExperiment","genesMissed":99,"mdate":"2013-01-28 13:40:47"}
+# Sample Output
+# experiment.json
+# {"origFileName":"filename","geneMapped":4886,"samples":8,"geneTotal":4985,"cdate":"2013-01-28 13:40:47","desc":"user input","organism":"some org","owner":"user name","title":"user input","pmid":"user input","expid":"whatever","collectionType":"ExpressionExperiment","genesMissed":99,"mdate":"2013-01-28 13:40:47"}
 
-#expression.json
-#{"expression":[{"log_ratio":"0.912","na_feature_id":"36731006","exp_locus_tag":"VBISalEnt101322_0001","pid":"8f2e7338-9f04-4ba5-9fe2-5365c857d57fS0","z_score":"-0.23331085637221843"}]
+# expression.json
+# {"expression":[{"log_ratio":"0.912","na_feature_id":"36731006","exp_locus_tag":"VBISalEnt101322_0001","pid":"8f2e7338-9f04-4ba5-9fe2-5365c857d57fS0","z_score":"-0.23331085637221843"}]
 
-#mapping.json
-#{"mapping":{"unmapped_list":[{"exp_locus_tag":"VBISalEnt101322_pg001"}],"unmapped_ids":99,"mapped_list":[{"na_feature_id":"36731006","exp_locus_tag":"VBISalEnt101322_0001"}],"mapped_ids":4886}}
+# mapping.json
+# {"mapping":{"unmapped_list":[{"exp_locus_tag":"VBISalEnt101322_pg001"}],"unmapped_ids":99,"mapped_list":[{"na_feature_id":"36731006","exp_locus_tag":"VBISalEnt101322_0001"}],"mapped_ids":4886}}
 
-#sample.json
-#{"sample":[{"sig_log_ratio":2675,"expmean":"1.258","sampleUserGivenId":"LB_stat_AerobicM9_stat_aerobic","expname":"LB_stat_AerobicM9_stat_aerobic","pid":"8f2e7338-9f04-4ba5-9fe2-5365c857d57fS0","genes":4429,"sig_z_score":139,"expstddev":"1.483"}]}
+# sample.json
+# {"sample":[{"sig_log_ratio":2675,"expmean":"1.258","sampleUserGivenId":"LB_stat_AerobicM9_stat_aerobic","expname":"LB_stat_AerobicM9_stat_aerobic","pid":"8f2e7338-9f04-4ba5-9fe2-5365c857d57fS0","genes":4429,"sig_z_score":139,"expstddev":"1.483"}]}
 
 
 def pretty_print_POST(req):
     """
     printed and may differ from the actual request.
     """
-    print('{}\n{}\n{}\n\n{}'.format(
-        '-----------START-----------',
-        req.method + ' ' + req.url,
-        '\n'.join('{}: {}'.format(k, v) for k, v in req.headers.items()),
-        req.body,
-    ))
+    print(
+        "{}\n{}\n{}\n\n{}".format(
+            "-----------START-----------",
+            req.method + " " + req.url,
+            "\n".join("{}: {}".format(k, v) for k, v in req.headers.items()),
+            req.body,
+        )
+    )
 
-#convert gene list format to gene matrix
-#there is definitely a more efficient conversion than this...
+
+# convert gene list format to gene matrix
+# there is definitely a more efficient conversion than this...
 def gene_list_to_matrix(cur_table):
-    comparisons=set(cur_table['sampleUserGivenId'])
-    genes=set(cur_table['exp_locus_tag'])
-    result=pd.DataFrame(index=list(genes), columns=list(comparisons))
-    result['exp_locus_tag']=result.index
-    gene_pos=cur_table.columns.get_loc('exp_locus_tag')
-    comparison_pos=cur_table.columns.get_loc('sampleUserGivenId')
-    ratio_pos=cur_table.columns.get_loc('log_ratio')
+    comparisons = set(cur_table["sampleUserGivenId"])
+    genes = set(cur_table["exp_locus_tag"])
+    result = pd.DataFrame(index=list(genes), columns=list(comparisons))
+    result["exp_locus_tag"] = result.index
+    gene_pos = cur_table.columns.get_loc("exp_locus_tag")
+    comparison_pos = cur_table.columns.get_loc("sampleUserGivenId")
+    ratio_pos = cur_table.columns.get_loc("log_ratio")
     for row in cur_table.iterrows():
-        gene_id=row[-1][gene_pos]
-        comp=row[-1][comparison_pos]
-        ratio=row[-1][ratio_pos]
-        result[comp][gene_id]=ratio
+        gene_id = row[-1][gene_pos]
+        comp = row[-1][comparison_pos]
+        ratio = row[-1][ratio_pos]
+        result[comp][gene_id] = ratio
     return result
 
-#convert gene matrix format to gene list
-#there is definitely a more efficient conversion than this...
+
+# convert gene matrix format to gene list
+# there is definitely a more efficient conversion than this...
 def gene_matrix_to_list(cur_table):
-    result=pd.melt(cur_table, id_vars=['exp_locus_tag'], var_name='sampleUserGivenId', value_name='log_ratio')
+    result = pd.melt(
+        cur_table,
+        id_vars=["exp_locus_tag"],
+        var_name="sampleUserGivenId",
+        value_name="log_ratio",
+    )
     return result
+
 
 def list_to_mapping_table(cur_table):
-    genes=set(cur_table['exp_locus_tag'])
+    genes = set(cur_table["exp_locus_tag"])
     if len(genes) == 0:
-       sys.stderr.write("No genes in differential expression gmx file\n")
-       sys.exit(2) 
-    result=pd.DataFrame(index=list(genes))
-    result['exp_locus_tag']=result.index
+        sys.stderr.write("No genes in differential expression gmx file\n")
+        sys.exit(2)
+    result = pd.DataFrame(index=list(genes))
+    result["exp_locus_tag"] = result.index
     return result
 
-#deal with weird naming of columns.
+
+# deal with weird naming of columns.
 def fix_headers(cur_table, parameter_type, die):
-    def fix_name(x, all_columns): 
-        fixed_name=' '.join(x.split()).strip().lower().replace(" ","_")
-        #patrics downloadable template is not consistent with its help info
-        if fixed_name.endswith('s') and fixed_name[:-1] in set(all_columns):
-            fixed_name=fixed_name[:-1]
+    def fix_name(x, all_columns):
+        fixed_name = " ".join(x.split()).strip().lower().replace(" ", "_")
+        # patrics downloadable template is not consistent with its help info
+        if fixed_name.endswith("s") and fixed_name[:-1] in set(all_columns):
+            fixed_name = fixed_name[:-1]
         return fixed_name
 
-    matrix_columns=['gene_id']
-    list_columns=['gene_id', 'comparison_id', 'log_ratio']
-    template_columns=["comparison_id","title","pubmed","accession","organism","strain","gene_modification","experiment_condition","time_point"]
-    all_columns=list_columns+template_columns
-    check_columns=None
-    target_setup=None
-    if parameter_type=="xfile":
-        target_setup= "gene_list" if all([(fix_name(x,all_columns) in list_columns) for x in cur_table.columns]) else "gene_matrix"
+    matrix_columns = ["gene_id"]
+    list_columns = ["gene_id", "comparison_id", "log_ratio"]
+    template_columns = [
+        "comparison_id",
+        "title",
+        "pubmed",
+        "accession",
+        "organism",
+        "strain",
+        "gene_modification",
+        "experiment_condition",
+        "time_point",
+    ]
+    all_columns = list_columns + template_columns
+    check_columns = None
+    target_setup = None
+    if parameter_type == "xfile":
+        target_setup = (
+            "gene_list"
+            if all(
+                [(fix_name(x, all_columns) in list_columns) for x in cur_table.columns]
+            )
+            else "gene_matrix"
+        )
     else:
-	    target_setup="template"
-    limit_columns=True
-    if target_setup == 'gene_matrix':
-        check_columns=matrix_columns
-        limit_columns=False
-        rename={'gene_id': 'exp_locus_tag'}
-    elif target_setup == 'gene_list':
-        check_columns=list_columns
-        rename={'comparison_id':'sampleUserGivenId','gene_id': 'exp_locus_tag'}
-    elif target_setup == 'template':
-        check_columns=template_columns
-        rename={'comparison_id':'sampleUserGivenId', 'title':'expname', 'gene_modification':'mutant', 'experiment_condition':'condition', 'time_point':'timepoint'}
+        target_setup = "template"
+    limit_columns = True
+    if target_setup == "gene_matrix":
+        check_columns = matrix_columns
+        limit_columns = False
+        rename = {"gene_id": "exp_locus_tag"}
+    elif target_setup == "gene_list":
+        check_columns = list_columns
+        rename = {"comparison_id": "sampleUserGivenId", "gene_id": "exp_locus_tag"}
+    elif target_setup == "template":
+        check_columns = template_columns
+        rename = {
+            "comparison_id": "sampleUserGivenId",
+            "title": "expname",
+            "gene_modification": "mutant",
+            "experiment_condition": "condition",
+            "time_point": "timepoint",
+        }
     else:
-        sys.stderr.write("unrecognized setup "+target_setup+"\n")
-        if die: assert False
-    cur_table.columns=[fix_name(x,all_columns) if fix_name(x,all_columns) in check_columns else x for x in cur_table.columns]
+        sys.stderr.write("unrecognized setup " + target_setup + "\n")
+        if die:
+            assert False
+    cur_table.columns = [
+        fix_name(x, all_columns) if fix_name(x, all_columns) in check_columns else x
+        for x in cur_table.columns
+    ]
     columns_ok = True
     for i in check_columns:
-        columns_ok=columns_ok and i in cur_table.columns
+        columns_ok = columns_ok and i in cur_table.columns
     if not columns_ok:
-            sys.stderr.write("Missing appropriate column names in "+target_setup+"\n")
-            if die: assert False
+        sys.stderr.write("Missing appropriate column names in " + target_setup + "\n")
+        if die:
+            assert False
     if limit_columns:
-        cur_table=cur_table[check_columns]
+        cur_table = cur_table[check_columns]
     if rename:
-       cur_table=cur_table.rename(columns=rename)
+        cur_table = cur_table.rename(columns=rename)
     return (target_setup, cur_table)
 
-#read in the comparisons data and metadata
+
+# read in the comparisons data and metadata
 def process_table(target_file, param_type, die, target_format="start", tries=0):
-    tries+=1
-    starting=False
-    target_setup=None
+    tries += 1
+    starting = False
+    target_setup = None
     if not os.path.exists(target_file):
-        sys.stderr.write("can't find target file "+target_file+"\n")
-        if die: sys.exit(2)
-    if target_format=="start":
-        starting=True
+        sys.stderr.write("can't find target file " + target_file + "\n")
+        if die:
+            sys.exit(2)
+    if target_format == "start":
+        starting = True
         fileName, fileExtension = os.path.splitext(target_file)
-        target_format=fileExtension.replace('.','').lower()
-    if starting and not target_format in set(["csv","tsv","xls","xlsx"]):
-        #temp_handle=open(target_file, 'rb')
-        temp_handle=open(target_file, 'r')
-        target_sep=csv.Sniffer().sniff("\n".join(list(islice(temp_handle,10))))
+        target_format = fileExtension.replace(".", "").lower()
+    if starting and not target_format in set(["csv", "tsv", "xls", "xlsx"]):
+        # temp_handle=open(target_file, 'rb')
+        temp_handle = open(target_file, "r")
+        target_sep = csv.Sniffer().sniff("\n".join(list(islice(temp_handle, 10))))
         temp_handle.close()
     # target_sep shouldn't be empty, but if it is just use tsv
     if not target_sep:
         target_sep = {}
         target_sep["delimeter"] = "\t"
-    if target_sep.delimiter=="\t":
-        target_format="tsv"
-        sys.stdout.write("guessing "+target_format+" format\n")
-    elif target_sep.delimiter==",":
-        target_format="csv"
-        sys.stdout.write("guessing "+target_format+" format\n")
-		
-    cur_table=None
-    next_up="tsv"
+    if target_sep.delimiter == "\t":
+        target_format = "tsv"
+        sys.stdout.write("guessing " + target_format + " format\n")
+    elif target_sep.delimiter == ",":
+        target_format = "csv"
+        sys.stdout.write("guessing " + target_format + " format\n")
+
+    cur_table = None
+    next_up = "tsv"
     try:
-        if target_format == 'tsv':
-            next_up="csv"
-            cur_table=pd.read_table(target_file, header=0)
-        elif target_format == 'csv':
-            next_up="xls"
-            cur_table=pd.read_csv(target_file, header=0)
-        elif target_format == 'xls' or target_format == 'xlsx':
-            cur_table=pd.io.excel.read_excel(target_file, 0, index_col=None)
+        if target_format == "tsv":
+            next_up = "csv"
+            cur_table = pd.read_table(target_file, header=0)
+        elif target_format == "csv":
+            next_up = "xls"
+            cur_table = pd.read_csv(target_file, header=0)
+        elif target_format == "xls" or target_format == "xlsx":
+            cur_table = pd.io.excel.read_excel(target_file, 0, index_col=None)
         else:
-            sys.stderr.write("unrecognized format "+target_format+" for "+target_setup+"\n")
-            if die: 
+            sys.stderr.write(
+                "unrecognized format " + target_format + " for " + target_setup + "\n"
+            )
+            if die:
                 sys.exit(2)
-            
-        #assume the first column is "gene_id" for the comparison table and rename it as "gene_id" to handle user misspelled column name for gene_id                                                                                         
-        if param_type=="xfile":
-            cur_table=cur_table.rename(columns={cur_table.columns[0]:'gene_id'})            
-        target_setup, cur_table=fix_headers(cur_table, param_type, die)
-    except Exception as e: 
-        sys.stdout.write("failed at reading "+target_format+" format\n")
+
+        # assume the first column is "gene_id" for the comparison table and rename it as "gene_id" to handle user misspelled column name for gene_id
+        if param_type == "xfile":
+            cur_table = cur_table.rename(columns={cur_table.columns[0]: "gene_id"})
+        target_setup, cur_table = fix_headers(cur_table, param_type, die)
+    except Exception as e:
+        sys.stdout.write("failed at reading " + target_format + " format\n")
         if tries > 5:
             raise Exception(e)
         else:
-            sys.stdout.write("guessing "+next_up+" format\n")
+            sys.stdout.write("guessing " + next_up + " format\n")
             return process_table(target_file, param_type, die, next_up, tries)
     return (target_setup, cur_table)
 
-#{source_id_type:"refseq_locus_tag || alt_locus_tag || feature_id", 
-#data_type: "Transcriptomics || Proteomics || Phenomics", 
-#experiment_title: "User input", experiment_description: "User input",
-#organism name: "user input", pubmed_id: "user_input"}
 
-#Sample Output
-#experiment.json
-#{"origFileName":"filename","geneMapped":4886,"samples":8,"geneTotal":4985,"cdate":"2013-01-28 13:40:47","desc":"user input","organism":"some org","owner":"user name","title":"user input","pmid":"user input","expid":"whatever","collectionType":"ExpressionExperiment","genesMissed":99,"mdate":"2013-01-28 13:40:47"}
-def create_experiment_file(output_path, mapping_dict, sample_dict, expression_dict, form_data, experiment_id):
-    experiment_dict={"geneMapped":mapping_dict["mapping"]["mapped_ids"],"samples":len(sample_dict['sample']),"geneTotal":mapping_dict["mapping"]["mapped_ids"]+mapping_dict["mapping"]["unmapped_ids"],"desc":form_data.get('desc',form_data.get("experiment_description","")),"organism":form_data.get('organism',''),"title":form_data.get("title",form_data.get("experiment_title","")),"pmid":form_data.get("pmid",""),"expid":experiment_id,"collectionType":"ExpressionExperiment","genesMissed":mapping_dict["mapping"]["unmapped_ids"]}
-    output_file=os.path.join(output_path, 'experiment.json')
-    out_handle=open(output_file, 'w')
+# {source_id_type:"refseq_locus_tag || alt_locus_tag || feature_id",
+# data_type: "Transcriptomics || Proteomics || Phenomics",
+# experiment_title: "User input", experiment_description: "User input",
+# organism name: "user input", pubmed_id: "user_input"}
+
+
+# Sample Output
+# experiment.json
+# {"origFileName":"filename","geneMapped":4886,"samples":8,"geneTotal":4985,"cdate":"2013-01-28 13:40:47","desc":"user input","organism":"some org","owner":"user name","title":"user input","pmid":"user input","expid":"whatever","collectionType":"ExpressionExperiment","genesMissed":99,"mdate":"2013-01-28 13:40:47"}
+def create_experiment_file(
+    output_path, mapping_dict, sample_dict, expression_dict, form_data, experiment_id
+):
+    experiment_dict = {
+        "geneMapped": mapping_dict["mapping"]["mapped_ids"],
+        "samples": len(sample_dict["sample"]),
+        "geneTotal": mapping_dict["mapping"]["mapped_ids"]
+        + mapping_dict["mapping"]["unmapped_ids"],
+        "desc": form_data.get("desc", form_data.get("experiment_description", "")),
+        "organism": form_data.get("organism", ""),
+        "title": form_data.get("title", form_data.get("experiment_title", "")),
+        "pmid": form_data.get("pmid", ""),
+        "expid": experiment_id,
+        "collectionType": "ExpressionExperiment",
+        "genesMissed": mapping_dict["mapping"]["unmapped_ids"],
+    }
+    output_file = os.path.join(output_path, "experiment.json")
+    out_handle = open(output_file, "w")
     json.dump(experiment_dict, out_handle)
     out_handle.close()
     return experiment_dict
-    
 
-#expression.json
-#{"expression":[{"log_ratio":"0.912","na_feature_id":"36731006","exp_locus_tag":"VBISalEnt101322_0001","pid":"8f2e7338-9f04-4ba5-9fe2-5365c857d57fS0","z_score":"-0.23331085637221843"}]
- 
-#sample.json
-#{"sample":[{"sig_log_ratio":2675,"expmean":"1.258","sampleUserGivenId":"LB_stat_AerobicM9_stat_aerobic","expname":"LB_stat_AerobicM9_stat_aerobic","pid":"8f2e7338-9f04-4ba5-9fe2-5365c857d57fS0","genes":4429,"sig_z_score":139,"expstddev":"1.483"}]}
 
-def create_comparison_files(output_path, comparisons_table, mfile, form_data, experiment_id, sig_z, sig_log):
-    #create dicts for json
-    sample_dict={'sample':[]}
-    expression_dict={'expression':[]}
-    #create stats table for sample.json
-    grouped=comparisons_table.groupby(["sampleUserGivenId"], sort=False)
-    sample_stats=grouped.agg([np.mean, np.std])['log_ratio']
-    sample_stats=sample_stats.rename_axis('contrast') # rename index column title
-    sample_stats=sample_stats.rename(columns={'mean':'expmean','std':'expstddev'})
-    sample_stats["genes"]=grouped.count()["exp_locus_tag"]
-    sample_stats["pid"]=[str(experiment_id)+"S"+str(i) for i in range(0,len(sample_stats))]
-    sample_stats["sampleUserGivenId"]=sample_stats.index
-    sample_stats["expname"]=sample_stats.index
-    #get zscore and significance columns
-    comparisons_table["z_score"]=grouped.transform(stats.zscore)["log_ratio"]
-    comparisons_table["sig_z"]=comparisons_table["z_score"].abs() >= sig_z
-    comparisons_table["sig_log"]=comparisons_table["log_ratio"].abs() >= sig_log
-    #store counts in stats
-    z_score_breakdown=comparisons_table.groupby(["sampleUserGivenId","sig_z"], sort=False).count()['z_score'].unstack()
+# expression.json
+# {"expression":[{"log_ratio":"0.912","na_feature_id":"36731006","exp_locus_tag":"VBISalEnt101322_0001","pid":"8f2e7338-9f04-4ba5-9fe2-5365c857d57fS0","z_score":"-0.23331085637221843"}]
+
+# sample.json
+# {"sample":[{"sig_log_ratio":2675,"expmean":"1.258","sampleUserGivenId":"LB_stat_AerobicM9_stat_aerobic","expname":"LB_stat_AerobicM9_stat_aerobic","pid":"8f2e7338-9f04-4ba5-9fe2-5365c857d57fS0","genes":4429,"sig_z_score":139,"expstddev":"1.483"}]}
+
+
+def create_comparison_files(
+    output_path, comparisons_table, mfile, form_data, experiment_id, sig_z, sig_log
+):
+    # create dicts for json
+    sample_dict = {"sample": []}
+    expression_dict = {"expression": []}
+    # create stats table for sample.json
+    grouped = comparisons_table.groupby(["sampleUserGivenId"], sort=False)
+    sample_stats = grouped.agg([np.mean, np.std])["log_ratio"]
+    sample_stats = sample_stats.rename_axis("contrast")  # rename index column title
+    sample_stats = sample_stats.rename(columns={"mean": "expmean", "std": "expstddev"})
+    sample_stats["genes"] = grouped.count()["exp_locus_tag"]
+    sample_stats["pid"] = [
+        str(experiment_id) + "S" + str(i) for i in range(0, len(sample_stats))
+    ]
+    sample_stats["sampleUserGivenId"] = sample_stats.index
+    sample_stats["expname"] = sample_stats.index
+    # get zscore and significance columns
+    comparisons_table["z_score"] = grouped.transform(stats.zscore)["log_ratio"]
+    comparisons_table["sig_z"] = comparisons_table["z_score"].abs() >= sig_z
+    comparisons_table["sig_log"] = comparisons_table["log_ratio"].abs() >= sig_log
+    # store counts in stats
+    z_score_breakdown = (
+        comparisons_table.groupby(["sampleUserGivenId", "sig_z"], sort=False)
+        .count()["z_score"]
+        .unstack()
+    )
     if True in z_score_breakdown:
-        sample_stats["sig_z_score"]=z_score_breakdown[True]
+        sample_stats["sig_z_score"] = z_score_breakdown[True]
     else:
-        z_score_breakdown.columns=[True]
-        z_score_breakdown[True]=z_score_breakdown[True].apply(lambda x: 0)
-        sample_stats["sig_z_score"]=z_score_breakdown[True]
+        z_score_breakdown.columns = [True]
+        z_score_breakdown[True] = z_score_breakdown[True].apply(lambda x: 0)
+        sample_stats["sig_z_score"] = z_score_breakdown[True]
 
-    log_breakdown=comparisons_table.groupby(["sampleUserGivenId","sig_log"], sort=False).count()['log_ratio'].unstack()
+    log_breakdown = (
+        comparisons_table.groupby(["sampleUserGivenId", "sig_log"], sort=False)
+        .count()["log_ratio"]
+        .unstack()
+    )
     if True in log_breakdown:
-        sample_stats["sig_log_ratio"]=log_breakdown[True]
+        sample_stats["sig_log_ratio"] = log_breakdown[True]
     else:
-        log_breakdown.columns=[True]
-        log_breakdown[True]=log_breakdown[True].apply(lambda x: 0)
-        sample_stats["sig_log_ratio"]=log_breakdown[True]
-    sample_stats["sig_log_ratio"]=sample_stats["sig_log_ratio"].fillna(0).astype('int64')
-    sample_stats["sig_z_score"]=sample_stats["sig_z_score"].fillna(0).astype('int64')
-    #set pid's for expression.json
-    comparisons_table=comparisons_table.merge(sample_stats[["pid","sampleUserGivenId"]], how="left", on="sampleUserGivenId")
-    #pull in metadata spreadsheet if provided
+        log_breakdown.columns = [True]
+        log_breakdown[True] = log_breakdown[True].apply(lambda x: 0)
+        sample_stats["sig_log_ratio"] = log_breakdown[True]
+    sample_stats["sig_log_ratio"] = (
+        sample_stats["sig_log_ratio"].fillna(0).astype("int64")
+    )
+    sample_stats["sig_z_score"] = sample_stats["sig_z_score"].fillna(0).astype("int64")
+    # set pid's for expression.json
+    comparisons_table = comparisons_table.merge(
+        sample_stats[["pid", "sampleUserGivenId"]], how="left", on="sampleUserGivenId"
+    )
+    # pull in metadata spreadsheet if provided
     if mfile and mfile.strip():
         sys.stdout.write("reading metadata template\n")
-        target_setup, meta_table=process_table(mfile, "mfile", die=True)
+        target_setup, meta_table = process_table(mfile, "mfile", die=True)
         try:
-            meta_key="sampleUserGivenId"
-            to_add=meta_table.columns-sample_stats.columns
-            meta_table=meta_table.set_index('sampleUserGivenId')
+            meta_key = "sampleUserGivenId"
+            to_add = meta_table.columns - sample_stats.columns
+            meta_table = meta_table.set_index("sampleUserGivenId")
             sample_stats.update(meta_table)
-            sample_stats=sample_stats.merge(meta_table[to_add], left_index=True, right_index=True, how='left')
+            sample_stats = sample_stats.merge(
+                meta_table[to_add], left_index=True, right_index=True, how="left"
+            )
         except:
             sys.stderr.write("failed to parse user provide metadata template\n")
             sys.exit(2)
-    #populate json dicts
-    sample_stats=sample_stats.fillna("")
-    sample_dict['sample']=json.loads(sample_stats.to_json(orient='records', date_format='iso'))
-    #sample_dict['sample']=sample_stats.to_dict(outtype='records')
-    cols = [col for col in comparisons_table.columns if col not in ['sig_z', 'sig_log']]
-    expression_dict['expression']=json.loads(comparisons_table[cols].to_json(orient='records'))
-    output_file=os.path.join(output_path, 'sample.json')
-    out_handle=open(output_file, 'w')
+    # populate json dicts
+    sample_stats = sample_stats.fillna("")
+    sample_dict["sample"] = json.loads(
+        sample_stats.to_json(orient="records", date_format="iso")
+    )
+    # sample_dict['sample']=sample_stats.to_dict(outtype='records')
+    cols = [col for col in comparisons_table.columns if col not in ["sig_z", "sig_log"]]
+    expression_dict["expression"] = json.loads(
+        comparisons_table[cols].to_json(orient="records")
+    )
+    output_file = os.path.join(output_path, "sample.json")
+    out_handle = open(output_file, "w")
     json.dump(sample_dict, out_handle)
     out_handle.close()
-    output_file=os.path.join(output_path, 'expression.json')
-    out_handle=open(output_file, 'w')
+    output_file = os.path.join(output_path, "expression.json")
+    out_handle = open(output_file, "w")
     json.dump(expression_dict, out_handle)
     out_handle.close()
     return (sample_dict, expression_dict)
-    
-    
 
-#mapping.json
-#{"mapping":{"unmapped_list":[{"exp_locus_tag":"VBISalEnt101322_pg001"}],"unmapped_ids":99,"mapped_list":[{"na_feature_id":"36731006","exp_locus_tag":"VBISalEnt101322_0001"}],"mapped_ids":4886}}
 
-#creates mapping.json for results
+# mapping.json
+# {"mapping":{"unmapped_list":[{"exp_locus_tag":"VBISalEnt101322_pg001"}],"unmapped_ids":99,"mapped_list":[{"na_feature_id":"36731006","exp_locus_tag":"VBISalEnt101322_0001"}],"mapped_ids":4886}}
+
+
+# creates mapping.json for results
 def create_mapping_file(output_path, mapping_table, form_data):
-    mapping_dict={"mapping":{"unmapped_list":[],"unmapped_ids":0,"mapped_list":[],"mapped_ids":0}}
-    mapping_dict['mapping']['unmapped_list']=mapping_table[mapping_table.isnull().any(axis=1)][['exp_locus_tag']].to_dict('records')
-    mapping_dict['mapping']['mapped_list']=mapping_table[mapping_table.notnull().all(axis=1)].to_dict('records')
-    mapping_dict['mapping']['unmapped_ids']=len(mapping_dict['mapping']['unmapped_list'])
-    mapping_dict['mapping']['mapped_ids']=len(mapping_dict['mapping']['mapped_list'])
-    output_file=os.path.join(output_path, 'mapping.json')
-    out_handle=open(output_file, 'w')
+    mapping_dict = {
+        "mapping": {
+            "unmapped_list": [],
+            "unmapped_ids": 0,
+            "mapped_list": [],
+            "mapped_ids": 0,
+        }
+    }
+    mapping_dict["mapping"]["unmapped_list"] = mapping_table[
+        mapping_table.isnull().any(axis=1)
+    ][["exp_locus_tag"]].to_dict("records")
+    mapping_dict["mapping"]["mapped_list"] = mapping_table[
+        mapping_table.notnull().all(axis=1)
+    ].to_dict("records")
+    mapping_dict["mapping"]["unmapped_ids"] = len(
+        mapping_dict["mapping"]["unmapped_list"]
+    )
+    mapping_dict["mapping"]["mapped_ids"] = len(mapping_dict["mapping"]["mapped_list"])
+    output_file = os.path.join(output_path, "mapping.json")
+    out_handle = open(output_file, "w")
     json.dump(mapping_dict, out_handle)
     out_handle.close()
     return mapping_dict
 
-    #mapped_list=[{form_data["source_id_type"]: i["Map ID"], "exp_locus_tag":i['Gene ID']} for i in mapping_table[mapping_table.notnull().any(axis=1)]]
-    #mapped_list=[{form_data["source_id_type"]: i["Map ID"], "exp_locus_tag":i["Gene ID"]} for i in mapping_table.query('Gene ID != @np.nan')]
+    # mapped_list=[{form_data["source_id_type"]: i["Map ID"], "exp_locus_tag":i['Gene ID']} for i in mapping_table[mapping_table.notnull().any(axis=1)]]
+    # mapped_list=[{form_data["source_id_type"]: i["Map ID"], "exp_locus_tag":i["Gene ID"]} for i in mapping_table.query('Gene ID != @np.nan')]
 
 
-def place_ids(query_results,cur_table,form_data):
-    source_types=form_data["source_types"]+form_data["int_types"]
-    count=0
+def place_ids(query_results, cur_table, form_data):
+    source_types = form_data["source_types"] + form_data["int_types"]
+    count = 0
     try:
-        for d in query_results.json()['response']['docs']:
-            source_ids=[]
-            target_id=None
+        for d in query_results.json()["response"]["docs"]:
+            source_ids = []
+            target_id = None
             for id_type in source_types:
                 if id_type in d:
                     source_ids.append(d[id_type])
-            
-            if 'feature_id' in d:
-                target_id=d['feature_id']
+
+            if "feature_id" in d:
+                target_id = d["feature_id"]
             if target_id:
-                #because which of the source id's are in the input data check them locally against the exp_locus_tag
+                # because which of the source id's are in the input data check them locally against the exp_locus_tag
                 for source_id in source_ids:
                     if source_id in cur_table["feature_id"]:
-                        count+=1
-                        cur_table["feature_id"][source_id]=target_id
+                        count += 1
+                        cur_table["feature_id"][source_id] = target_id
                         break
     except ValueError:
-        sys.stderr.write("mapping failed. either PATRICs API is down or the Gene IDs are unknown\n")
+        sys.stderr.write(
+            "mapping failed. either PATRICs API is down or the Gene IDs are unknown\n"
+        )
         raise
-    if count==0:
-        sys.stderr.write("mapping failed. either PATRICs API is down or the Gene IDs are unknown\n")
+    if count == 0:
+        sys.stderr.write(
+            "mapping failed. either PATRICs API is down or the Gene IDs are unknown\n"
+        )
         sys.exit(2)
+
 
 def make_map_query(id_list, form_data, server_setup, chunk_size):
     id_list = id_list.apply(str)
-    source_types=form_data["source_types"]
-    int_types=form_data["int_types"]
-    current_query={'q':""}
-    map_queries=[]
-    int_ids=[]
+    source_types = form_data["source_types"]
+    int_types = form_data["int_types"]
+    current_query = {"q": ""}
+    map_queries = []
+    int_ids = []
     if "source_id_type" in form_data and len(form_data["source_id_type"]) > 0:
-        source_types=[form_data["source_id_type"]]
+        source_types = [form_data["source_id_type"]]
     else:
         for id in id_list:
             if np.issubdtype(type(id), np.number) or id.isdigit():
                 int_ids.append(str(id))
         if len(int_ids):
             for s_type in int_types:
-                map_queries.append("("+s_type+":("+" OR ".join(int_ids)+"))")
+                map_queries.append("(" + s_type + ":(" + " OR ".join(int_ids) + "))")
     for s_type in source_types:
-        map_queries.append("("+s_type+":("+" OR ".join(id_list)+"))")
+        map_queries.append("(" + s_type + ":(" + " OR ".join(id_list) + "))")
     if "host" in form_data and form_data["host"]:
-        current_query["q"]+="("+" OR ".join(map_queries)+") AND annotation:RefSeq"
+        current_query["q"] += "(" + " OR ".join(map_queries) + ") AND annotation:RefSeq"
     else:
-        current_query["q"]+="("+" OR ".join(map_queries)+") AND annotation:PATRIC"
+        current_query["q"] += "(" + " OR ".join(map_queries) + ") AND annotation:PATRIC"
     if "genome_id" in form_data and form_data["genome_id"]:
-        current_query["q"]+=" AND genome_id:"+form_data["genome_id"]
-    current_query["fl"]="feature_id,"+",".join(source_types+int_types)
-    current_query["rows"]="20000"
-    current_query["wt"]="json"
-    headers = {"Content-Type": "application/solrquery+x-www-form-urlencoded", "accept":"application/solr+json"}
-    #print "switch THE HEADER BACK!"
-    #headers = {'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'}
-    req = requests.Request('POST', server_setup["data_api"], headers=headers, data=current_query)
+        current_query["q"] += " AND genome_id:" + form_data["genome_id"]
+    current_query["fl"] = "feature_id," + ",".join(source_types + int_types)
+    current_query["rows"] = "20000"
+    current_query["wt"] = "json"
+    headers = {
+        "Content-Type": "application/solrquery+x-www-form-urlencoded",
+        "accept": "application/solr+json",
+    }
+    # print "switch THE HEADER BACK!"
+    # headers = {'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'}
+    req = requests.Request(
+        "POST", server_setup["data_api"], headers=headers, data=current_query
+    )
     authenticateByEnv(req)
     prepared = req.prepare()
-    #pretty_print_POST(prepared)
+    # pretty_print_POST(prepared)
     s = requests.Session()
-    response=s.send(prepared)
+    response = s.send(prepared)
     if not response.ok:
-        sys.stderr.write("Error code %s invoking data api: %s\nquery: %s\n" % (response.status_code, response.text, current_query))
+        sys.stderr.write(
+            "Error code %s invoking data api: %s\nquery: %s\n"
+            % (response.status_code, response.text, current_query)
+        )
         sys.exit(2)
     return response
 
 
 def chunker(seq, size):
-    return (seq[pos:pos + size] for pos in range(0, len(seq), size))
+    return (seq[pos : pos + size] for pos in range(0, len(seq), size))
+
 
 def map_gene_ids(cur_table, form_data, server_setup, host=False):
-    cur_table["feature_id"]=np.nan
-    chunk_size=1000
+    cur_table["feature_id"] = np.nan
+    chunk_size = 1000
     if host:
         for source_id in cur_table["exp_locus_tag"]:
-            cur_table["feature_id"][source_id]=source_id
+            cur_table["feature_id"][source_id] = source_id
     else:
-        for i in chunker(cur_table['exp_locus_tag'], chunk_size):
-            mapping_results=make_map_query(i, form_data, server_setup, chunk_size)
+        for i in chunker(cur_table["exp_locus_tag"], chunk_size):
+            mapping_results = make_map_query(i, form_data, server_setup, chunk_size)
             place_ids(mapping_results, cur_table, form_data)
-          
 
 
 def main():
-    sig_z=2
-    sig_log=1
-    valid_formats=set(['csv', 'tsv', 'xls', 'xlsx'])
-    valid_setups=set(['gene_matrix','gene_list'])
-    
-    #req_info=['xformat','xsetup','source_id_type','data_type','experiment_title','experiment_description','organism']
-    req_info=['data_type','experiment_title','experiment_description','organism']
-    
+    sig_z = 2
+    sig_log = 1
+    valid_formats = set(["csv", "tsv", "xls", "xlsx"])
+    valid_setups = set(["gene_matrix", "gene_list"])
+
+    # req_info=['xformat','xsetup','source_id_type','data_type','experiment_title','experiment_description','organism']
+    req_info = ["data_type", "experiment_title", "experiment_description", "organism"]
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--xfile', help='the source Expression comparisons file', required=True)
-    parser.add_argument('--mfile', help='the metadata template if it exists', required=False)
-    parser.add_argument('--output_path', help='location for output', required=True)
-    parser.add_argument('--host', help='host genome, prevent id mapping', action='store_true', default=False, required=False)
+    parser.add_argument(
+        "--xfile", help="the source Expression comparisons file", required=True
+    )
+    parser.add_argument(
+        "--mfile", help="the metadata template if it exists", required=False
+    )
+    parser.add_argument("--output_path", help="location for output", required=True)
+    parser.add_argument(
+        "--host",
+        help="host genome, prevent id mapping",
+        action="store_true",
+        default=False,
+        required=False,
+    )
     userinfo = parser.add_mutually_exclusive_group(required=True)
-    userinfo.add_argument('--ufile', help='json file from user input')
-    userinfo.add_argument('--ustring', help='json string from user input')
+    userinfo.add_argument("--ufile", help="json file from user input")
+    userinfo.add_argument("--ustring", help="json string from user input")
     serverinfo = parser.add_mutually_exclusive_group(required=True)
-    serverinfo.add_argument('--sfile', help='server setup JSON file')
-    serverinfo.add_argument('--sstring', help='server setup JSON string')
+    serverinfo.add_argument("--sfile", help="server setup JSON file")
+    serverinfo.add_argument("--sstring", help="server setup JSON string")
     map_args = parser.parse_args()
-    if len(sys.argv) ==1:
+    if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(2)
 
-    #get comparison and metadata files
-    xfile=map_args.xfile
-    mfile=map_args.mfile if 'mfile' in map_args else None
+    # get comparison and metadata files
+    xfile = map_args.xfile
+    mfile = map_args.mfile if "mfile" in map_args else None
 
-    #parse user form data
-    form_data=None
-    user_parse=None
-    server_parse=None
-    parse_server = json.loads if 'sstring' in map_args else json.load
-        
+    # parse user form data
+    form_data = None
+    user_parse = None
+    server_parse = None
+    parse_server = json.loads if "sstring" in map_args else json.load
+
     try:
-        form_data = json.loads(map_args.ustring) if map_args.ustring else json.load(open(map_args.ufile,'r'))
+        form_data = (
+            json.loads(map_args.ustring)
+            if map_args.ustring
+            else json.load(open(map_args.ufile, "r"))
+        )
     except:
         sys.stderr.write("Failed to parse user provided form data \n")
         raise
-    #parse setup data
+    # parse setup data
     try:
-        server_setup= json.loads(map_args.sstring) if map_args.sstring else json.load(open(map_args.sfile,'r'))
+        server_setup = (
+            json.loads(map_args.sstring)
+            if map_args.sstring
+            else json.load(open(map_args.sfile, "r"))
+        )
     except:
         sys.stderr.write("Failed to parse server data\n")
         raise
 
-    #part of auto-detection of id type add source id types to map from
-    form_data["source_types"]=["refseq_locus_tag","alt_locus_tag","feature_id","protein_id","patric_id"]#,"gi"]
-    form_data["int_types"]=["gi","gene_id"]
+    # part of auto-detection of id type add source id types to map from
+    form_data["source_types"] = [
+        "refseq_locus_tag",
+        "alt_locus_tag",
+        "feature_id",
+        "protein_id",
+        "patric_id",
+    ]  # ,"gi"]
+    form_data["int_types"] = ["gi", "gene_id"]
 
-    #make sure all required info present
-    missing=[x not in form_data for x in req_info]
-    if (any(missing)):
-        sys.stderr.write("Missing required user input data: "+" ".join([req_info[i] for i in range(len(missing)) if missing[i]])+"\n")
+    # make sure all required info present
+    missing = [x not in form_data for x in req_info]
+    if any(missing):
+        sys.stderr.write(
+            "Missing required user input data: "
+            + " ".join([req_info[i] for i in range(len(missing)) if missing[i]])
+            + "\n"
+        )
         sys.exit(2)
-    #if (mfile or 'metadata_format' in form_data) and ('metadata_format' not in form_data or not mfile):
+    # if (mfile or 'metadata_format' in form_data) and ('metadata_format' not in form_data or not mfile):
     #    sys.stderr.write("Expression transformation: (file,format) pair must be given for metadata template\n")
-        #sys.exit(2)
+    # sys.exit(2)
 
-
-    #read comparisons file
+    # read comparisons file
     sys.stdout.write("reading comparisons file\n")
-    target_setup, comparisons_table=process_table(xfile, "xfile", die=True)
+    target_setup, comparisons_table = process_table(xfile, "xfile", die=True)
 
-    output_path=map_args.output_path
+    output_path = map_args.output_path
 
-    #convert gene matrix to list
-    if target_setup == 'gene_matrix':
-        comparisons_table=gene_matrix_to_list(comparisons_table)
+    # convert gene matrix to list
+    if target_setup == "gene_matrix":
+        comparisons_table = gene_matrix_to_list(comparisons_table)
 
-    #limit log ratios
-    comparisons_table.loc[comparisons_table["log_ratio"] > 1000000, 'log_ratio']=1000000
-    comparisons_table.loc[comparisons_table["log_ratio"] < -1000000, 'log_ratio']=-1000000
-    comparisons_table=comparisons_table.dropna()
-    comparisons_table=comparisons_table[comparisons_table.exp_locus_tag != "-"]
+    # limit log ratios
+    comparisons_table.loc[
+        comparisons_table["log_ratio"] > 1000000, "log_ratio"
+    ] = 1000000
+    comparisons_table.loc[
+        comparisons_table["log_ratio"] < -1000000, "log_ratio"
+    ] = -1000000
+    comparisons_table = comparisons_table.dropna()
+    comparisons_table = comparisons_table[comparisons_table.exp_locus_tag != "-"]
 
-    #map gene ids
-    mapping_table=list_to_mapping_table(comparisons_table)
+    # map gene ids
+    mapping_table = list_to_mapping_table(comparisons_table)
     map_gene_ids(mapping_table, form_data, server_setup, map_args.host)
-    comparisons_table=comparisons_table.merge(mapping_table, how='left', on='exp_locus_tag')
+    comparisons_table = comparisons_table.merge(
+        mapping_table, how="left", on="exp_locus_tag"
+    )
 
-    #create json files to represent experiment
-    experiment_id=str(uuid.uuid1())
-    mapping_dict=create_mapping_file(output_path, mapping_table, form_data)
-    (sample_dict, expression_dict) = create_comparison_files(output_path, comparisons_table, mfile, form_data, experiment_id, sig_z, sig_log)
-    experiment_dict=create_experiment_file(output_path, mapping_dict, sample_dict, expression_dict, form_data, experiment_id)
-    sys.stdout.write(json.dumps(experiment_dict)+"\n")
-    
-     
+    # create json files to represent experiment
+    experiment_id = str(uuid.uuid1())
+    mapping_dict = create_mapping_file(output_path, mapping_table, form_data)
+    (sample_dict, expression_dict) = create_comparison_files(
+        output_path, comparisons_table, mfile, form_data, experiment_id, sig_z, sig_log
+    )
+    experiment_dict = create_experiment_file(
+        output_path,
+        mapping_dict,
+        sample_dict,
+        expression_dict,
+        form_data,
+        experiment_id,
+    )
+    sys.stdout.write(json.dumps(experiment_dict) + "\n")
+
+
 if __name__ == "__main__":
     main()

--- a/scripts/expression_transform_bvbrc.py
+++ b/scripts/expression_transform_bvbrc.py
@@ -210,7 +210,7 @@ def process_table(
         starting = True
         fileName, fileExtension = os.path.splitext(target_file)
         target_format = fileExtension.replace(".", "").lower()
-    if starting and not target_format in set(["csv", "tsv", "xls", "xlsx"]):
+    if starting and target_format not in set(["csv", "tsv", "xls", "xlsx"]):
         # temp_handle=open(target_file, 'rb')
         temp_handle = open(target_file, "r")
         target_sep = csv.Sniffer().sniff(
@@ -551,7 +551,7 @@ def make_map_query(id_list, form_data, server_setup, chunk_size):
 
 
 def chunker(seq, size):
-    return (seq[pos : pos + size] for pos in range(0, len(seq), size))
+    return (seq[pos: pos + size] for pos in range(0, len(seq), size))
 
 
 def map_gene_ids(cur_table, form_data, server_setup, host=False):

--- a/scripts/expression_transform_bvbrc.py
+++ b/scripts/expression_transform_bvbrc.py
@@ -29,11 +29,11 @@ pd.options.mode.chained_assignment = None
 """
 {xformat:"csv || tsv || xls ||  xlsx",
 xsetup:"gene_matrix || gene_list",
-source_id_type:"refseq_locus_tag || alt_locus_tag || feature_id || gi || gene_id || protein_id || seed_id", 
-data_type: "Transcriptomics || Proteomics || Phenomics", 
-title: "User input", 
+source_id_type:"refseq_locus_tag || alt_locus_tag || feature_id || gi || gene_id || protein_id || seed_id",
+data_type: "Transcriptomics || Proteomics || Phenomics",
+title: "User input",
 desc: "User input",
-organism: "user input", 
+organism: "user input",
 pmid: "user_input",
 output_path: "path",
 "metadata_format":"csv || tsv || xls ||  xlsx"}
@@ -140,7 +140,10 @@ def fix_headers(cur_table, parameter_type, die):
         target_setup = (
             "gene_list"
             if all(
-                [(fix_name(x, all_columns) in list_columns) for x in cur_table.columns]
+                [
+                    (fix_name(x, all_columns) in list_columns)
+                    for x in cur_table.columns
+                ]
             )
             else "gene_matrix"
         )
@@ -153,7 +156,10 @@ def fix_headers(cur_table, parameter_type, die):
         rename = {"gene_id": "exp_locus_tag"}
     elif target_setup == "gene_list":
         check_columns = list_columns
-        rename = {"comparison_id": "sampleUserGivenId", "gene_id": "exp_locus_tag"}
+        rename = {
+            "comparison_id": "sampleUserGivenId",
+            "gene_id": "exp_locus_tag",
+        }
     elif target_setup == "template":
         check_columns = template_columns
         rename = {
@@ -168,14 +174,18 @@ def fix_headers(cur_table, parameter_type, die):
         if die:
             assert False
     cur_table.columns = [
-        fix_name(x, all_columns) if fix_name(x, all_columns) in check_columns else x
+        fix_name(x, all_columns)
+        if fix_name(x, all_columns) in check_columns
+        else x
         for x in cur_table.columns
     ]
     columns_ok = True
     for i in check_columns:
         columns_ok = columns_ok and i in cur_table.columns
     if not columns_ok:
-        sys.stderr.write("Missing appropriate column names in " + target_setup + "\n")
+        sys.stderr.write(
+            "Missing appropriate column names in " + target_setup + "\n"
+        )
         if die:
             assert False
     if limit_columns:
@@ -186,7 +196,9 @@ def fix_headers(cur_table, parameter_type, die):
 
 
 # read in the comparisons data and metadata
-def process_table(target_file, param_type, die, target_format="start", tries=0):
+def process_table(
+    target_file, param_type, die, target_format="start", tries=0
+):
     tries += 1
     starting = False
     target_setup = None
@@ -201,7 +213,9 @@ def process_table(target_file, param_type, die, target_format="start", tries=0):
     if starting and not target_format in set(["csv", "tsv", "xls", "xlsx"]):
         # temp_handle=open(target_file, 'rb')
         temp_handle = open(target_file, "r")
-        target_sep = csv.Sniffer().sniff("\n".join(list(islice(temp_handle, 10))))
+        target_sep = csv.Sniffer().sniff(
+            "\n".join(list(islice(temp_handle, 10)))
+        )
         temp_handle.close()
     # target_sep shouldn't be empty, but if it is just use tsv
     if not target_sep:
@@ -227,14 +241,20 @@ def process_table(target_file, param_type, die, target_format="start", tries=0):
             cur_table = pd.io.excel.read_excel(target_file, 0, index_col=None)
         else:
             sys.stderr.write(
-                "unrecognized format " + target_format + " for " + target_setup + "\n"
+                "unrecognized format "
+                + target_format
+                + " for "
+                + target_setup
+                + "\n"
             )
             if die:
                 sys.exit(2)
 
         # assume the first column is "gene_id" for the comparison table and rename it as "gene_id" to handle user misspelled column name for gene_id
         if param_type == "xfile":
-            cur_table = cur_table.rename(columns={cur_table.columns[0]: "gene_id"})
+            cur_table = cur_table.rename(
+                columns={cur_table.columns[0]: "gene_id"}
+            )
         target_setup, cur_table = fix_headers(cur_table, param_type, die)
     except Exception as e:
         sys.stdout.write("failed at reading " + target_format + " format\n")
@@ -256,14 +276,21 @@ def process_table(target_file, param_type, die, target_format="start", tries=0):
 # experiment.json
 # {"origFileName":"filename","geneMapped":4886,"samples":8,"geneTotal":4985,"cdate":"2013-01-28 13:40:47","desc":"user input","organism":"some org","owner":"user name","title":"user input","pmid":"user input","expid":"whatever","collectionType":"ExpressionExperiment","genesMissed":99,"mdate":"2013-01-28 13:40:47"}
 def create_experiment_file(
-    output_path, mapping_dict, sample_dict, expression_dict, form_data, experiment_id
+    output_path,
+    mapping_dict,
+    sample_dict,
+    expression_dict,
+    form_data,
+    experiment_id,
 ):
     experiment_dict = {
         "geneMapped": mapping_dict["mapping"]["mapped_ids"],
         "samples": len(sample_dict["sample"]),
         "geneTotal": mapping_dict["mapping"]["mapped_ids"]
         + mapping_dict["mapping"]["unmapped_ids"],
-        "desc": form_data.get("desc", form_data.get("experiment_description", "")),
+        "desc": form_data.get(
+            "desc", form_data.get("experiment_description", "")
+        ),
         "organism": form_data.get("organism", ""),
         "title": form_data.get("title", form_data.get("experiment_title", "")),
         "pmid": form_data.get("pmid", ""),
@@ -286,7 +313,13 @@ def create_experiment_file(
 
 
 def create_comparison_files(
-    output_path, comparisons_table, mfile, form_data, experiment_id, sig_z, sig_log
+    output_path,
+    comparisons_table,
+    mfile,
+    form_data,
+    experiment_id,
+    sig_z,
+    sig_log,
 ):
     # create dicts for json
     sample_dict = {"sample": []}
@@ -294,8 +327,12 @@ def create_comparison_files(
     # create stats table for sample.json
     grouped = comparisons_table.groupby(["sampleUserGivenId"], sort=False)
     sample_stats = grouped.agg([np.mean, np.std])["log_ratio"]
-    sample_stats = sample_stats.rename_axis("contrast")  # rename index column title
-    sample_stats = sample_stats.rename(columns={"mean": "expmean", "std": "expstddev"})
+    sample_stats = sample_stats.rename_axis(
+        "contrast"
+    )  # rename index column title
+    sample_stats = sample_stats.rename(
+        columns={"mean": "expmean", "std": "expstddev"}
+    )
     sample_stats["genes"] = grouped.count()["exp_locus_tag"]
     sample_stats["pid"] = [
         str(experiment_id) + "S" + str(i) for i in range(0, len(sample_stats))
@@ -305,7 +342,9 @@ def create_comparison_files(
     # get zscore and significance columns
     comparisons_table["z_score"] = grouped.transform(stats.zscore)["log_ratio"]
     comparisons_table["sig_z"] = comparisons_table["z_score"].abs() >= sig_z
-    comparisons_table["sig_log"] = comparisons_table["log_ratio"].abs() >= sig_log
+    comparisons_table["sig_log"] = (
+        comparisons_table["log_ratio"].abs() >= sig_log
+    )
     # store counts in stats
     z_score_breakdown = (
         comparisons_table.groupby(["sampleUserGivenId", "sig_z"], sort=False)
@@ -333,10 +372,14 @@ def create_comparison_files(
     sample_stats["sig_log_ratio"] = (
         sample_stats["sig_log_ratio"].fillna(0).astype("int64")
     )
-    sample_stats["sig_z_score"] = sample_stats["sig_z_score"].fillna(0).astype("int64")
+    sample_stats["sig_z_score"] = (
+        sample_stats["sig_z_score"].fillna(0).astype("int64")
+    )
     # set pid's for expression.json
     comparisons_table = comparisons_table.merge(
-        sample_stats[["pid", "sampleUserGivenId"]], how="left", on="sampleUserGivenId"
+        sample_stats[["pid", "sampleUserGivenId"]],
+        how="left",
+        on="sampleUserGivenId",
     )
     # pull in metadata spreadsheet if provided
     if mfile and mfile.strip():
@@ -348,10 +391,15 @@ def create_comparison_files(
             meta_table = meta_table.set_index("sampleUserGivenId")
             sample_stats.update(meta_table)
             sample_stats = sample_stats.merge(
-                meta_table[to_add], left_index=True, right_index=True, how="left"
+                meta_table[to_add],
+                left_index=True,
+                right_index=True,
+                how="left",
             )
         except:
-            sys.stderr.write("failed to parse user provide metadata template\n")
+            sys.stderr.write(
+                "failed to parse user provide metadata template\n"
+            )
             sys.exit(2)
     # populate json dicts
     sample_stats = sample_stats.fillna("")
@@ -359,7 +407,11 @@ def create_comparison_files(
         sample_stats.to_json(orient="records", date_format="iso")
     )
     # sample_dict['sample']=sample_stats.to_dict(outtype='records')
-    cols = [col for col in comparisons_table.columns if col not in ["sig_z", "sig_log"]]
+    cols = [
+        col
+        for col in comparisons_table.columns
+        if col not in ["sig_z", "sig_log"]
+    ]
     expression_dict["expression"] = json.loads(
         comparisons_table[cols].to_json(orient="records")
     )
@@ -397,7 +449,9 @@ def create_mapping_file(output_path, mapping_table, form_data):
     mapping_dict["mapping"]["unmapped_ids"] = len(
         mapping_dict["mapping"]["unmapped_list"]
     )
-    mapping_dict["mapping"]["mapped_ids"] = len(mapping_dict["mapping"]["mapped_list"])
+    mapping_dict["mapping"]["mapped_ids"] = len(
+        mapping_dict["mapping"]["mapped_list"]
+    )
     output_file = os.path.join(output_path, "mapping.json")
     out_handle = open(output_file, "w")
     json.dump(mapping_dict, out_handle)
@@ -455,13 +509,19 @@ def make_map_query(id_list, form_data, server_setup, chunk_size):
                 int_ids.append(str(id))
         if len(int_ids):
             for s_type in int_types:
-                map_queries.append("(" + s_type + ":(" + " OR ".join(int_ids) + "))")
+                map_queries.append(
+                    "(" + s_type + ":(" + " OR ".join(int_ids) + "))"
+                )
     for s_type in source_types:
         map_queries.append("(" + s_type + ":(" + " OR ".join(id_list) + "))")
     if "host" in form_data and form_data["host"]:
-        current_query["q"] += "(" + " OR ".join(map_queries) + ") AND annotation:RefSeq"
+        current_query["q"] += (
+            "(" + " OR ".join(map_queries) + ") AND annotation:RefSeq"
+        )
     else:
-        current_query["q"] += "(" + " OR ".join(map_queries) + ") AND annotation:PATRIC"
+        current_query["q"] += (
+            "(" + " OR ".join(map_queries) + ") AND annotation:PATRIC"
+        )
     if "genome_id" in form_data and form_data["genome_id"]:
         current_query["q"] += " AND genome_id:" + form_data["genome_id"]
     current_query["fl"] = "feature_id," + ",".join(source_types + int_types)
@@ -502,7 +562,9 @@ def map_gene_ids(cur_table, form_data, server_setup, host=False):
             cur_table["feature_id"][source_id] = source_id
     else:
         for i in chunker(cur_table["exp_locus_tag"], chunk_size):
-            mapping_results = make_map_query(i, form_data, server_setup, chunk_size)
+            mapping_results = make_map_query(
+                i, form_data, server_setup, chunk_size
+            )
             place_ids(mapping_results, cur_table, form_data)
 
 
@@ -513,7 +575,12 @@ def main():
     valid_setups = set(["gene_matrix", "gene_list"])
 
     # req_info=['xformat','xsetup','source_id_type','data_type','experiment_title','experiment_description','organism']
-    req_info = ["data_type", "experiment_title", "experiment_description", "organism"]
+    req_info = [
+        "data_type",
+        "experiment_title",
+        "experiment_description",
+        "organism",
+    ]
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -522,7 +589,9 @@ def main():
     parser.add_argument(
         "--mfile", help="the metadata template if it exists", required=False
     )
-    parser.add_argument("--output_path", help="location for output", required=True)
+    parser.add_argument(
+        "--output_path", help="location for output", required=True
+    )
     parser.add_argument(
         "--host",
         help="host genome, prevent id mapping",
@@ -586,7 +655,9 @@ def main():
     if any(missing):
         sys.stderr.write(
             "Missing required user input data: "
-            + " ".join([req_info[i] for i in range(len(missing)) if missing[i]])
+            + " ".join(
+                [req_info[i] for i in range(len(missing)) if missing[i]]
+            )
             + "\n"
         )
         sys.exit(2)
@@ -612,7 +683,9 @@ def main():
         comparisons_table["log_ratio"] < -1000000, "log_ratio"
     ] = -1000000
     comparisons_table = comparisons_table.dropna()
-    comparisons_table = comparisons_table[comparisons_table.exp_locus_tag != "-"]
+    comparisons_table = comparisons_table[
+        comparisons_table.exp_locus_tag != "-"
+    ]
 
     # map gene ids
     mapping_table = list_to_mapping_table(comparisons_table)
@@ -625,7 +698,13 @@ def main():
     experiment_id = str(uuid.uuid1())
     mapping_dict = create_mapping_file(output_path, mapping_table, form_data)
     (sample_dict, expression_dict) = create_comparison_files(
-        output_path, comparisons_table, mfile, form_data, experiment_id, sig_z, sig_log
+        output_path,
+        comparisons_table,
+        mfile,
+        form_data,
+        experiment_id,
+        sig_z,
+        sig_log,
     )
     experiment_dict = create_experiment_file(
         output_path,

--- a/scripts/rnaseqPrepDE.py
+++ b/scripts/rnaseqPrepDE.py
@@ -4,30 +4,81 @@ from math import ceil
 from optparse import OptionParser
 from operator import itemgetter
 
-parser=OptionParser(description='Generates two CSV files containing the count matrices for genes and transcripts, using the coverage values found in the output of `stringtie -e`')
-parser.add_option('-i', '--input', '--in', default='.', help="a folder containing all sample sub-directories, or a text file with sample ID and path to its GTF file on each line [default: %default/]")
-parser.add_option('-g', default='gene_count_matrix.csv', help="where to output the gene count matrix [default: %default")
-parser.add_option('-t', default='transcript_count_matrix.csv', help="where to output the transcript count matrix [default: %default]")
-parser.add_option('-l', '--length', default=75, type='int', help="the average read length [default: %default]")
-parser.add_option('-p', '--pattern', default=".", help="a regular expression that selects the sample subdirectories")
-parser.add_option('-c', '--cluster', action="store_true", help="whether to cluster genes that overlap with different gene IDs, ignoring ones with geneID pattern (see below)")
-parser.add_option('-s', '--string', default="MSTRG", help="if a different prefix is used for geneIDs assigned by StringTie [default: %default]")
-parser.add_option('-k', '--key', default="prepG", help="if clustering, what prefix to use for geneIDs assigned by this script [default: %default]")
-parser.add_option('-v', action="store_true", help="enable verbose processing")
+parser = OptionParser(
+    description="Generates two CSV files containing the count matrices for genes and transcripts, using the coverage values found in the output of `stringtie -e`"
+)
+parser.add_option(
+    "-i",
+    "--input",
+    "--in",
+    default=".",
+    help="a folder containing all sample sub-directories, or a text file with sample ID and path to its GTF file on each line [default: %default/]",
+)
+parser.add_option(
+    "-g",
+    default="gene_count_matrix.csv",
+    help="where to output the gene count matrix [default: %default",
+)
+parser.add_option(
+    "-t",
+    default="transcript_count_matrix.csv",
+    help="where to output the transcript count matrix [default: %default]",
+)
+parser.add_option(
+    "-l",
+    "--length",
+    default=75,
+    type="int",
+    help="the average read length [default: %default]",
+)
+parser.add_option(
+    "-p",
+    "--pattern",
+    default=".",
+    help="a regular expression that selects the sample subdirectories",
+)
+parser.add_option(
+    "-c",
+    "--cluster",
+    action="store_true",
+    help="whether to cluster genes that overlap with different gene IDs, ignoring ones with geneID pattern (see below)",
+)
+parser.add_option(
+    "-s",
+    "--string",
+    default="MSTRG",
+    help="if a different prefix is used for geneIDs assigned by StringTie [default: %default]",
+)
+parser.add_option(
+    "-k",
+    "--key",
+    default="prepG",
+    help="if clustering, what prefix to use for geneIDs assigned by this script [default: %default]",
+)
+parser.add_option("-v", action="store_true", help="enable verbose processing")
 
-parser.add_option('--legend', default="legend.csv", help="if clustering, where to output the legend file mapping transcripts to assigned geneIDs [default: %default]")
-(opts, args)=parser.parse_args()
+parser.add_option(
+    "--legend",
+    default="legend.csv",
+    help="if clustering, where to output the legend file mapping transcripts to assigned geneIDs [default: %default]",
+)
+(opts, args) = parser.parse_args()
 
-samples = [] # List of tuples. If sample list, (first column, path). Else, (subdirectory name, path to gtf file in subdirectory)
-if (os.path.isfile(opts.input)):
+samples = (
+    []
+)  # List of tuples. If sample list, (first column, path). Else, (subdirectory name, path to gtf file in subdirectory)
+if os.path.isfile(opts.input):
     # gtfList = True
     try:
-        fin = open(opts.input, 'r')
+        fin = open(opts.input, "r")
         for line in fin:
-            if line[0] != '#':
-                lineLst = tuple(line.strip().split(None,2))
-                if (len(lineLst) != 2):
-                    print("Error: line should have a sample ID and a file path:\n%s" % (line.strip()))
+            if line[0] != "#":
+                lineLst = tuple(line.strip().split(None, 2))
+                if len(lineLst) != 2:
+                    print(
+                        "Error: line should have a sample ID and a file path:\n%s"
+                        % (line.strip())
+                    )
                     exit(1)
                 if lineLst[0] in samples:
                     print("Error: non-unique sample ID (%s)" % (lineLst[0]))
@@ -43,32 +94,32 @@ else:
     # gtfList = False
     ## Check that opts.input directory exists
     if not os.path.isdir(opts.input):
-      parser.print_help()
-      print(" ")
-      print("Error: sub-directory '%s' not found!" % (opts.input))
-      sys.exit(1)
+        parser.print_help()
+        print(" ")
+        print("Error: sub-directory '%s' not found!" % (opts.input))
+        sys.exit(1)
     #####
     ## Collect all samples file paths and if empty print help message and quit
     #####
     samples = []
     for i in next(os.walk(opts.input))[1]:
-        if re.search(opts.pattern,i):
-         for f in glob.iglob(os.path.join(opts.input,i,"*.gtf")):
-            samples.append((i,f)) 
+        if re.search(opts.pattern, i):
+            for f in glob.iglob(os.path.join(opts.input, i, "*.gtf")):
+                samples.append((i, f))
 
 if len(samples) == 0:
-  parser.print_help()
-  print(" ")
-  print("Error: no GTF files found under base directory %s !" % (opts.input))
-  sys.exit(1)
+    parser.print_help()
+    print(" ")
+    print("Error: no GTF files found under base directory %s !" % (opts.input))
+    sys.exit(1)
 
-RE_GENE_ID=re.compile('gene_id "([^"]+)"')
-RE_GENE_NAME=re.compile('gene_name "([^"]+)"')
-RE_TRANSCRIPT_ID=re.compile('transcript_id "([^"]+)"')
-RE_COVERAGE=re.compile('cov "([\-\+\d\.]+)"')
-RE_STRING=re.compile(re.escape(opts.string))
+RE_GENE_ID = re.compile('gene_id "([^"]+)"')
+RE_GENE_NAME = re.compile('gene_name "([^"]+)"')
+RE_TRANSCRIPT_ID = re.compile('transcript_id "([^"]+)"')
+RE_COVERAGE = re.compile('cov "([\-\+\d\.]+)"')
+RE_STRING = re.compile(re.escape(opts.string))
 
-RE_GFILE=re.compile('\-G\s*(\S+)') #assume filepath without spaces..
+RE_GFILE = re.compile("\-G\s*(\S+)")  # assume filepath without spaces..
 
 
 #####
@@ -77,121 +128,145 @@ RE_GFILE=re.compile('\-G\s*(\S+)') #assume filepath without spaces..
 
 samples.sort()
 
-#if opts.v:
+# if opts.v:
 #  print "Sample GTFs found:"
 #  for s in samples:
 #     print s[1]
 
+
 #####
-## Checks whether a given row is a transcript 
+## Checks whether a given row is a transcript
 ## other options: ex. exon, transcript, mRNA, 5'UTR
 #####
 def is_transcript(x):
-  return len(x)>2 and x[2]=="transcript"
+    return len(x) > 2 and x[2] == "transcript"
+
 
 def getGeneID(s, ctg, tid):
-  r=RE_GENE_ID.search(s)
-  #if r: return r.group(1)
-  rn=RE_GENE_NAME.search(s)
-  #if rn: return ctg+'|'+rn.group(1)
-  if r:
-    if rn: 
-      return r.group(1)+'|'+rn.group(1)
-    else:
-      return r.group(1)
-  return tid
+    r = RE_GENE_ID.search(s)
+    # if r: return r.group(1)
+    rn = RE_GENE_NAME.search(s)
+    # if rn: return ctg+'|'+rn.group(1)
+    if r:
+        if rn:
+            return r.group(1) + "|" + rn.group(1)
+        else:
+            return r.group(1)
+    return tid
+
 
 def getCov(s):
-  r=RE_COVERAGE.search(s)
-  if r:
-    v=float(r.group(1))
-    if v<0.0: v=0.0
-    return v
-  return 0.0
-
-def is_overlap(x,y): #NEEDS TO BE INTS!
-  return x[0]<=y[1] and y[0]<=x[1]
+    r = RE_COVERAGE.search(s)
+    if r:
+        v = float(r.group(1))
+        if v < 0.0:
+            v = 0.0
+        return v
+    return 0.0
 
 
-def t_overlap(t1, t2): #from badGenes: chromosome, strand, cluster, start, end, (e1start, e1end)...
-    if t1[0] != t2[0] or t1[1] != t2[1] or t1[5]<t2[4]: return False
+def is_overlap(x, y):  # NEEDS TO BE INTS!
+    return x[0] <= y[1] and y[0] <= x[1]
+
+
+def t_overlap(
+    t1, t2
+):  # from badGenes: chromosome, strand, cluster, start, end, (e1start, e1end)...
+    if t1[0] != t2[0] or t1[1] != t2[1] or t1[5] < t2[4]:
+        return False
     for i in range(6, len(t1)):
         for j in range(6, len(t2)):
-            if is_overlap(t1[i], t2[j]): return True
+            if is_overlap(t1[i], t2[j]):
+                return True
     return False
 
+
 ## Average Readlength
-read_len=opts.length
+read_len = opts.length
 
 ## Variables/Matrices to store t/g_counts
-t_count_matrix, g_count_matrix=[],[]
+t_count_matrix, g_count_matrix = [], []
 
 ##Get ready for clustering, stuff is once for all samples##
-geneIDs={} #key=transcript, value=cluster/gene_id
+geneIDs = {}  # key=transcript, value=cluster/gene_id
 
 
 ## For each of the sorted sample paths
 for s in samples:
-    badGenes=[] #list of bad genes (just ones that aren't MSTRG)
+    badGenes = []  # list of bad genes (just ones that aren't MSTRG)
     try:
         ## opts.input = parent directory of sample subdirectories
         ## s = sample currently iterating through
         ## os.path.join(opts.input,s,"*.gtf") path to current sample's GTF
         ## split = list of lists: [[chromosome, ...],...]
 
-        #with open(glob.iglob(os.path.join(opts.input,s,"*.gtf")).next()) as f:
+        # with open(glob.iglob(os.path.join(opts.input,s,"*.gtf")).next()) as f:
         #    split=[l.split('\t') for l in f.readlines()]
-#        if not gtfList:
-#            f = open(glob.iglob(os.path.join(opts.input,s[1],"*.gtf")).next())
-#        else:
-#            f = open(s[1])
+        #        if not gtfList:
+        #            f = open(glob.iglob(os.path.join(opts.input,s[1],"*.gtf")).next())
+        #        else:
+        #            f = open(s[1])
         with open(s[1]) as f:
-            split=[l.split('\t') for l in f.readlines()]
+            split = [l.split("\t") for l in f.readlines()]
 
         ## i = numLine; v = corresponding i-th GTF row
-        for i,v in enumerate(split):
+        for i, v in enumerate(split):
             if is_transcript(v):
-                t_id=RE_TRANSCRIPT_ID.search(v[8]).group(1)
+                t_id = RE_TRANSCRIPT_ID.search(v[8]).group(1)
                 try:
-                  g_id=getGeneID(v[8], v[0], t_id)
+                    g_id = getGeneID(v[8], v[0], t_id)
                 except:
-                  print("Problem parsing file %s at line:\n:%s\n" % (s[1], v))
-                  sys.exit(1)
+                    print("Problem parsing file %s at line:\n:%s\n" % (s[1], v))
+                    sys.exit(1)
                 geneIDs.setdefault(t_id, g_id)
                 if not RE_STRING.match(g_id):
-                    badGenes.append([v[0],v[6], t_id, g_id, min(int(v[3]),int(v[4])), max(int(v[3]),int(v[4]))]) #chromosome, strand, cluster/transcript id, start, end
-                    j=i+1
-                    while j<len(split) and split[j][2]=="exon":
-                        badGenes[len(badGenes)-1].append((min(int(split[j][3]), int(split[j][4])), max(int(split[j][3]), int(split[j][4]))))
-                        j+=1
+                    badGenes.append(
+                        [
+                            v[0],
+                            v[6],
+                            t_id,
+                            g_id,
+                            min(int(v[3]), int(v[4])),
+                            max(int(v[3]), int(v[4])),
+                        ]
+                    )  # chromosome, strand, cluster/transcript id, start, end
+                    j = i + 1
+                    while j < len(split) and split[j][2] == "exon":
+                        badGenes[len(badGenes) - 1].append(
+                            (
+                                min(int(split[j][3]), int(split[j][4])),
+                                max(int(split[j][3]), int(split[j][4])),
+                            )
+                        )
+                        j += 1
 
     except StopIteration:
         warnings.warn("Didn't get a GTF in that directory. Looking in another...")
 
-    else: #we found the "bad" genes!
+    else:  # we found the "bad" genes!
         break
 
 ##THE CLUSTERING BEGINS!##
-if opts.cluster and len(badGenes)>0:
-    clusters=[] #lists of lists (could be sets) or something of transcripts
-    badGenes.sort(key=itemgetter(3)) #sort by start coord...?
-    i=0
-    while i<len(badGenes): #rather un-pythonic
-        temp_cluster=[badGenes[i]]
+if opts.cluster and len(badGenes) > 0:
+    clusters = []  # lists of lists (could be sets) or something of transcripts
+    badGenes.sort(key=itemgetter(3))  # sort by start coord...?
+    i = 0
+    while i < len(badGenes):  # rather un-pythonic
+        temp_cluster = [badGenes[i]]
 
-        k=0
-        while k<len(temp_cluster):
-            j=i+1
-            while j<len(badGenes):
+        k = 0
+        while k < len(temp_cluster):
+            j = i + 1
+            while j < len(badGenes):
                 if t_overlap(temp_cluster[k], badGenes[j]):
                     temp_cluster.append(badGenes[j])
                     del badGenes[j]
                 else:
-                    j+=1
-            k+=1
-        if len(temp_cluster)>1:
+                    j += 1
+            k += 1
+        if len(temp_cluster) > 1:
             clusters.append([t[2] for t in temp_cluster])
-        i+=1
+        i += 1
 
     print(len(clusters))
 
@@ -199,109 +274,128 @@ if opts.cluster and len(badGenes)>0:
         c.sort()
 
     clusters.sort(key=itemgetter(0))
-    legend=[]
-    for u,c in enumerate(clusters):
-        my_ID=opts.key+str((u+1))
-        legend.append(list(itertools.chain.from_iterable([[my_ID],c]))) #my_ID, clustered transcript IDs
+    legend = []
+    for u, c in enumerate(clusters):
+        my_ID = opts.key + str((u + 1))
+        legend.append(
+            list(itertools.chain.from_iterable([[my_ID], c]))
+        )  # my_ID, clustered transcript IDs
         for t in c:
-            geneIDs[t]=my_ID
-##            geneIDs[t]="|".join(c) #duct-tape transcript IDs together, disregarding ref_gene_names and things like that
+            geneIDs[t] = my_ID
+    ##            geneIDs[t]="|".join(c) #duct-tape transcript IDs together, disregarding ref_gene_names and things like that
 
-    with open(opts.legend, 'w') as l_file:
-        my_writer=csv.writer(l_file)
+    with open(opts.legend, "w") as l_file:
+        my_writer = csv.writer(l_file)
         my_writer.writerows(legend)
 
-geneDict={} #key=gene/cluster, value=dictionary with key=sample, value=summed counts
-t_dict={}
-guidesFile='' # file given with -G for the 1st sample
+geneDict = {}  # key=gene/cluster, value=dictionary with key=sample, value=summed counts
+t_dict = {}
+guidesFile = ""  # file given with -G for the 1st sample
 for q, s in enumerate(samples):
     if opts.v:
-       print(">processing sample %s from file %s" % s)
-    lno=0
+        print(">processing sample %s from file %s" % s)
+    lno = 0
     try:
-        #with open(glob.iglob(os.path.join(opts.input,s,"*.gtf")).next()) as f: #grabs first .gtf file it finds inside the sample subdirectory
-#        if not gtfList:
-#            f = open(glob.iglob(os.path.join(opts.input,s[1],"*.gtf")).next())
-#        else:
+        # with open(glob.iglob(os.path.join(opts.input,s,"*.gtf")).next()) as f: #grabs first .gtf file it finds inside the sample subdirectory
+        #        if not gtfList:
+        #            f = open(glob.iglob(os.path.join(opts.input,s[1],"*.gtf")).next())
+        #        else:
         f = open(s[1])
-        transcript_len=0
-        
-        for l in f:
-            lno+=1
-            if l.startswith('#'):
-                if lno==1:
-                    ei=l.find('-e')
-                    if ei<0:
-                       print("Error: sample file %s was not generated with -e option!" % ( s[1] ))
-                       sys.exit(1)
-                    gf=RE_GFILE.search(l)
-                    if gf:
-                       gfile=gf.group(1)
-                       if guidesFile:
-                          if gfile != guidesFile:
-                             print("Warning: sample file %s generated with a different -G file (%s) than the first sample (%s)" % ( s[1], gfile, guidesFile ))
-                       else:
-                          guidesFile=gfile
-                    else:
-                       print("Error: sample %s was not processed with -G option!" % ( s[1] ))
-                       sys.exit(1)
-                continue
-            v=l.split('\t')
-            if v[2]=="transcript":
-                if transcript_len>0:
-##                        transcriptList.append((g_id, t_id, int(ceil(coverage*transcript_len/read_len))))
-                    t_dict.setdefault(t_id, {})
-                    t_dict[t_id].setdefault(s[0], int(ceil(coverage*transcript_len/read_len)))
-                t_id=RE_TRANSCRIPT_ID.search(v[len(v)-1]).group(1)
-                #g_id=RE_GENE_ID.search(v[len(v)-1]).group(1)
-                g_id=getGeneID(v[8], v[0], t_id)
-                #coverage=float(RE_COVERAGE.search(v[len(v)-1]).group(1))
-                coverage=getCov(v[8])
-                transcript_len=0
-            if v[2]=="exon":
-                transcript_len+=int(v[4])-int(v[3])+1 #because end coordinates are inclusive in GTF
+        transcript_len = 0
 
-##            transcriptList.append((g_id, t_id, int(ceil(coverage*transcript_len/read_len))))
+        for l in f:
+            lno += 1
+            if l.startswith("#"):
+                if lno == 1:
+                    ei = l.find("-e")
+                    if ei < 0:
+                        print(
+                            "Error: sample file %s was not generated with -e option!"
+                            % (s[1])
+                        )
+                        sys.exit(1)
+                    gf = RE_GFILE.search(l)
+                    if gf:
+                        gfile = gf.group(1)
+                        if guidesFile:
+                            if gfile != guidesFile:
+                                print(
+                                    "Warning: sample file %s generated with a different -G file (%s) than the first sample (%s)"
+                                    % (s[1], gfile, guidesFile)
+                                )
+                        else:
+                            guidesFile = gfile
+                    else:
+                        print(
+                            "Error: sample %s was not processed with -G option!"
+                            % (s[1])
+                        )
+                        sys.exit(1)
+                continue
+            v = l.split("\t")
+            if v[2] == "transcript":
+                if transcript_len > 0:
+                    ##                        transcriptList.append((g_id, t_id, int(ceil(coverage*transcript_len/read_len))))
+                    t_dict.setdefault(t_id, {})
+                    t_dict[t_id].setdefault(
+                        s[0], int(ceil(coverage * transcript_len / read_len))
+                    )
+                t_id = RE_TRANSCRIPT_ID.search(v[len(v) - 1]).group(1)
+                # g_id=RE_GENE_ID.search(v[len(v)-1]).group(1)
+                g_id = getGeneID(v[8], v[0], t_id)
+                # coverage=float(RE_COVERAGE.search(v[len(v)-1]).group(1))
+                coverage = getCov(v[8])
+                transcript_len = 0
+            if v[2] == "exon":
+                transcript_len += (
+                    int(v[4]) - int(v[3]) + 1
+                )  # because end coordinates are inclusive in GTF
+
+        ##            transcriptList.append((g_id, t_id, int(ceil(coverage*transcript_len/read_len))))
         t_dict.setdefault(t_id, {})
-        t_dict[t_id].setdefault(s[0], int(ceil(coverage*transcript_len/read_len)))
+        t_dict[t_id].setdefault(s[0], int(ceil(coverage * transcript_len / read_len)))
 
     except StopIteration:
-#        if not gtfList:
-#            warnings.warn("No GTF file found in " + os.path.join(opts.input,s[1]))
-#        else:
+        #        if not gtfList:
+        #            warnings.warn("No GTF file found in " + os.path.join(opts.input,s[1]))
+        #        else:
         warnings.warn("No GTF file found in " + s[1])
 
+    ##        transcriptList.sort(key=lambda bla: bla[1]) #gene_id
 
-##        transcriptList.sort(key=lambda bla: bla[1]) #gene_id
-    
-    for i,v in t_dict.items():
-##        print i,v
-       try:
-          geneDict.setdefault(geneIDs[i],{}) #gene_id
-          geneDict[geneIDs[i]].setdefault(s[0],0)
-          geneDict[geneIDs[i]][s[0]]+=v[s[0]]
-       except KeyError:
-          print("Error: could not locate transcript %s entry for sample %s" % ( i, s[0] ))
-          raise
+    for i, v in t_dict.items():
+        ##        print i,v
+        try:
+            geneDict.setdefault(geneIDs[i], {})  # gene_id
+            geneDict[geneIDs[i]].setdefault(s[0], 0)
+            geneDict[geneIDs[i]][s[0]] += v[s[0]]
+        except KeyError:
+            print(
+                "Error: could not locate transcript %s entry for sample %s" % (i, s[0])
+            )
+            raise
 
 if opts.v:
-   print("..writing %s " % ( opts.t ))
-with open(opts.t, 'w') as csvfile:
-   my_writer = csv.DictWriter(csvfile, fieldnames = ["transcript_id"] + [x for x,y in samples])
-   my_writer.writerow(dict((fn,fn) for fn in my_writer.fieldnames))
-   for i in t_dict:
+    print("..writing %s " % (opts.t))
+with open(opts.t, "w") as csvfile:
+    my_writer = csv.DictWriter(
+        csvfile, fieldnames=["transcript_id"] + [x for x, y in samples]
+    )
+    my_writer.writerow(dict((fn, fn) for fn in my_writer.fieldnames))
+    for i in t_dict:
         t_dict[i]["transcript_id"] = i
         my_writer.writerow(t_dict[i])
 if opts.v:
-   print("..writing %s " % ( opts.g ))
-with open(opts.g, 'w') as csvfile:
-   my_writer = csv.DictWriter(csvfile, fieldnames = ["gene_id"] + [x for x,y in samples])
-##    my_writer.writerow([""]+samples)
-##    my_writer.writerows(geneDict)
-   my_writer.writerow(dict((fn,fn) for fn in my_writer.fieldnames))
-   for i in geneDict:
-        geneDict[i]["gene_id"] = i #add gene_id to row
+    print("..writing %s " % (opts.g))
+with open(opts.g, "w") as csvfile:
+    my_writer = csv.DictWriter(
+        csvfile, fieldnames=["gene_id"] + [x for x, y in samples]
+    )
+    ##    my_writer.writerow([""]+samples)
+    ##    my_writer.writerows(geneDict)
+    my_writer.writerow(dict((fn, fn) for fn in my_writer.fieldnames))
+    for i in geneDict:
+        geneDict[i]["gene_id"] = i  # add gene_id to row
         my_writer.writerow(geneDict[i])
 if opts.v:
-   print("All done.")
-
+    print("All done.")

--- a/scripts/rnaseqPrepDE.py
+++ b/scripts/rnaseqPrepDE.py
@@ -92,14 +92,14 @@ if os.path.isfile(opts.input):
         exit(1)
 else:
     # gtfList = False
-    ## Check that opts.input directory exists
+    # Check that opts.input directory exists
     if not os.path.isdir(opts.input):
         parser.print_help()
         print(" ")
         print("Error: sub-directory '%s' not found!" % (opts.input))
         sys.exit(1)
     #####
-    ## Collect all samples file paths and if empty print help message and quit
+    # Collect all samples file paths and if empty print help message and quit
     #####
     samples = []
     for i in next(os.walk(opts.input))[1]:
@@ -113,17 +113,17 @@ if len(samples) == 0:
     print("Error: no GTF files found under base directory %s !" % (opts.input))
     sys.exit(1)
 
-RE_GENE_ID = re.compile('gene_id "([^"]+)"')
-RE_GENE_NAME = re.compile('gene_name "([^"]+)"')
-RE_TRANSCRIPT_ID = re.compile('transcript_id "([^"]+)"')
-RE_COVERAGE = re.compile('cov "([\-\+\d\.]+)"')
+RE_GENE_ID = re.compile(r'gene_id "([^"]+)"')
+RE_GENE_NAME = re.compile(r'gene_name "([^"]+)"')
+RE_TRANSCRIPT_ID = re.compile(r'transcript_id "([^"]+)"')
+RE_COVERAGE = re.compile(r'cov "([\-\+\d\.]+)"')
 RE_STRING = re.compile(re.escape(opts.string))
 
-RE_GFILE = re.compile("\-G\s*(\S+)")  # assume filepath without spaces..
+RE_GFILE = re.compile(r"\-G\s*(\S+)")  # assume filepath without spaces..
 
 
 #####
-## Sort the sample names by the sample ID
+# Sort the sample names by the sample ID
 #####
 
 samples.sort()
@@ -135,8 +135,8 @@ samples.sort()
 
 
 #####
-## Checks whether a given row is a transcript
-## other options: ex. exon, transcript, mRNA, 5'UTR
+# Checks whether a given row is a transcript
+# other options: ex. exon, transcript, mRNA, 5'UTR
 #####
 def is_transcript(x):
     return len(x) > 2 and x[2] == "transcript"
@@ -181,24 +181,24 @@ def t_overlap(
     return False
 
 
-## Average Readlength
+# Average Readlength
 read_len = opts.length
 
-## Variables/Matrices to store t/g_counts
+# Variables/Matrices to store t/g_counts
 t_count_matrix, g_count_matrix = [], []
 
-##Get ready for clustering, stuff is once for all samples##
+# Get ready for clustering, stuff is once for all samples##
 geneIDs = {}  # key=transcript, value=cluster/gene_id
 
 
-## For each of the sorted sample paths
+# For each of the sorted sample paths
 for s in samples:
     badGenes = []  # list of bad genes (just ones that aren't MSTRG)
     try:
-        ## opts.input = parent directory of sample subdirectories
-        ## s = sample currently iterating through
-        ## os.path.join(opts.input,s,"*.gtf") path to current sample's GTF
-        ## split = list of lists: [[chromosome, ...],...]
+        #  opts.input = parent directory of sample subdirectories
+        #  s = sample currently iterating through
+        #  os.path.join(opts.input,s,"*.gtf") path to current sample's GTF
+        #  split = list of lists: [[chromosome, ...],...]
 
         # with open(glob.iglob(os.path.join(opts.input,s,"*.gtf")).next()) as f:
         #    split=[l.split('\t') for l in f.readlines()]
@@ -209,14 +209,16 @@ for s in samples:
         with open(s[1]) as f:
             split = [l.split("\t") for l in f.readlines()]
 
-        ## i = numLine; v = corresponding i-th GTF row
+        # i = numLine; v = corresponding i-th GTF row
         for i, v in enumerate(split):
             if is_transcript(v):
                 t_id = RE_TRANSCRIPT_ID.search(v[8]).group(1)
                 try:
                     g_id = getGeneID(v[8], v[0], t_id)
                 except:
-                    print("Problem parsing file %s at line:\n:%s\n" % (s[1], v))
+                    print(
+                        "Problem parsing file %s at line:\n:%s\n" % (s[1], v)
+                    )
                     sys.exit(1)
                 geneIDs.setdefault(t_id, g_id)
                 if not RE_STRING.match(g_id):
@@ -241,12 +243,14 @@ for s in samples:
                         j += 1
 
     except StopIteration:
-        warnings.warn("Didn't get a GTF in that directory. Looking in another...")
+        warnings.warn(
+            "Didn't get a GTF in that directory. Looking in another..."
+        )
 
     else:  # we found the "bad" genes!
         break
 
-##THE CLUSTERING BEGINS!##
+# THE CLUSTERING BEGINS!##
 if opts.cluster and len(badGenes) > 0:
     clusters = []  # lists of lists (could be sets) or something of transcripts
     badGenes.sort(key=itemgetter(3))  # sort by start coord...?
@@ -282,13 +286,15 @@ if opts.cluster and len(badGenes) > 0:
         )  # my_ID, clustered transcript IDs
         for t in c:
             geneIDs[t] = my_ID
-    ##            geneIDs[t]="|".join(c) #duct-tape transcript IDs together, disregarding ref_gene_names and things like that
+    #             geneIDs[t]="|".join(c) #duct-tape transcript IDs together, disregarding ref_gene_names and things like that
 
     with open(opts.legend, "w") as l_file:
         my_writer = csv.writer(l_file)
         my_writer.writerows(legend)
 
-geneDict = {}  # key=gene/cluster, value=dictionary with key=sample, value=summed counts
+geneDict = (
+    {}
+)  # key=gene/cluster, value=dictionary with key=sample, value=summed counts
 t_dict = {}
 guidesFile = ""  # file given with -G for the 1st sample
 for q, s in enumerate(samples):
@@ -351,9 +357,11 @@ for q, s in enumerate(samples):
                     int(v[4]) - int(v[3]) + 1
                 )  # because end coordinates are inclusive in GTF
 
-        ##            transcriptList.append((g_id, t_id, int(ceil(coverage*transcript_len/read_len))))
+        #            transcriptList.append((g_id, t_id, int(ceil(coverage*transcript_len/read_len))))
         t_dict.setdefault(t_id, {})
-        t_dict[t_id].setdefault(s[0], int(ceil(coverage * transcript_len / read_len)))
+        t_dict[t_id].setdefault(
+            s[0], int(ceil(coverage * transcript_len / read_len))
+        )
 
     except StopIteration:
         #        if not gtfList:
@@ -361,17 +369,18 @@ for q, s in enumerate(samples):
         #        else:
         warnings.warn("No GTF file found in " + s[1])
 
-    ##        transcriptList.sort(key=lambda bla: bla[1]) #gene_id
+    #        transcriptList.sort(key=lambda bla: bla[1]) #gene_id
 
     for i, v in t_dict.items():
-        ##        print i,v
+        #        print i,v
         try:
             geneDict.setdefault(geneIDs[i], {})  # gene_id
             geneDict[geneIDs[i]].setdefault(s[0], 0)
             geneDict[geneIDs[i]][s[0]] += v[s[0]]
         except KeyError:
             print(
-                "Error: could not locate transcript %s entry for sample %s" % (i, s[0])
+                "Error: could not locate transcript %s entry for sample %s"
+                % (i, s[0])
             )
             raise
 
@@ -391,8 +400,8 @@ with open(opts.g, "w") as csvfile:
     my_writer = csv.DictWriter(
         csvfile, fieldnames=["gene_id"] + [x for x, y in samples]
     )
-    ##    my_writer.writerow([""]+samples)
-    ##    my_writer.writerows(geneDict)
+    #    my_writer.writerow([""]+samples)
+    #    my_writer.writerows(geneDict)
     my_writer.writerow(dict((fn, fn) for fn in my_writer.fieldnames))
     for i in geneDict:
         geneDict[i]["gene_id"] = i  # add gene_id to row

--- a/scripts/rnaseqPrepDE.py
+++ b/scripts/rnaseqPrepDE.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-import re, csv, sys, os, glob, warnings, itertools
+import re
+import csv
+import sys
+import os
+import glob
+import warnings
+import itertools
 from math import ceil
 from optparse import OptionParser
 from operator import itemgetter
@@ -341,7 +347,7 @@ for q, s in enumerate(samples):
             v = l.split("\t")
             if v[2] == "transcript":
                 if transcript_len > 0:
-                    ##                        transcriptList.append((g_id, t_id, int(ceil(coverage*transcript_len/read_len))))
+                    #                        transcriptList.append((g_id, t_id, int(ceil(coverage*transcript_len/read_len))))
                     t_dict.setdefault(t_id, {})
                     t_dict[t_id].setdefault(
                         s[0], int(ceil(coverage * transcript_len / read_len))

--- a/scripts/run_rnaseq.py
+++ b/scripts/run_rnaseq.py
@@ -1,30 +1,33 @@
 #!/usr/bin/python3
 
-#library modules
+# library modules
 import argparse, sys, os, json
 import requests
 import subprocess
 
-#pipeline modules
+# pipeline modules
 import experiment
 import process
 import report
+
 # import process_statistics
 from bvbrc_api import authenticateByEnv
 
-#https://www.nature.com/articles/s41598-020-76881-x
+# https://www.nature.com/articles/s41598-020-76881-x
 
 # valid recipes
-valid_recipes = ['HTSeq-DESeq','cufflinks','Host']
+valid_recipes = ["HTSeq-DESeq", "cufflinks", "Host"]
 
-def main(genome, experiment_dict, tool_params, output_dir, comparisons, session, map_args):
 
+def main(
+    genome, experiment_dict, tool_params, output_dir, comparisons, session, map_args
+):
     # TODO: assess reads and terminate gracefully if reads are not set up correctly
 
     # setup folder structure and genome databases
     setup(output_dir, experiment_dict, genome)
-    diffexp_flag = comparisons.check_diffexp() 
-    
+    diffexp_flag = comparisons.check_diffexp()
+
     ### process data independently of genomes
     # Fastqc
     preprocess = process.Preprocess()
@@ -34,7 +37,7 @@ def main(genome, experiment_dict, tool_params, output_dir, comparisons, session,
 
     # Trimming
     # TODO: replace threads with tool_params value
-    if map_args.trimming: 
+    if map_args.trimming:
         for condition in experiment_dict:
             for sample in experiment_dict[condition].get_sample_list():
                 preprocess.run_trimming(sample, 8)
@@ -48,7 +51,7 @@ def main(genome, experiment_dict, tool_params, output_dir, comparisons, session,
             alignment.run_sample_alignment(sample, 8)
 
     ### Align against genome
-    alignment.set_genome(genome) 
+    alignment.set_genome(genome)
     alignment_all_good = True
     for condition in experiment_dict:
         for sample in experiment_dict[condition].get_sample_list():
@@ -67,14 +70,21 @@ def main(genome, experiment_dict, tool_params, output_dir, comparisons, session,
         condition_count = 0
         for condition in experiment_dict:
             sample_count += len(experiment_dict[condition].get_sample_list())
-            if condition != 'no_condition':
+            if condition != "no_condition":
                 condition_count += 1
-        report_stats['num_samples'] = sample_count
-        report_stats['num_conditions'] = condition_count
+        report_stats["num_samples"] = sample_count
+        report_stats["num_conditions"] = condition_count
         # get recipe
-        report_stats['recipe'] = map_args.recipe
+        report_stats["recipe"] = map_args.recipe
         report_manager.run_multiqc(output_dir)
-        report_manager.create_report(genome, output_dir, experiment_dict, report_stats, map_args.workspace_dir, diffexp_flag)
+        report_manager.create_report(
+            genome,
+            output_dir,
+            experiment_dict,
+            report_stats,
+            map_args.workspace_dir,
+            diffexp_flag,
+        )
         sys.exit(0)
 
     # HTSeq(bacteria), Stringtie(host)
@@ -86,44 +96,44 @@ def main(genome, experiment_dict, tool_params, output_dir, comparisons, session,
     sample_list = []
     for condition in experiment_dict:
         samples = experiment_dict[condition].get_sample_list()
-        sample_list = sample_list + samples 
-    print('sample_list = {0}'.format(sample_list))
-    condition_output_list = quantifier.run_quantification(sample_list,8)
+        sample_list = sample_list + samples
+    print("sample_list = {0}".format(sample_list))
+    condition_output_list = quantifier.run_quantification(sample_list, 8)
     genome_quant_file = quantifier.create_genome_counts_table(output_dir, sample_list)
-    genome.add_genome_data('counts_table', genome_quant_file)
+    genome.add_genome_data("counts_table", genome_quant_file)
     # TODO: test host
     genome_quant_file = quantifier.create_genome_quant_table(output_dir, sample_list)
 
     # sample_list used in function below
     sample_list = []
     for condition in experiment_dict:
-        samples = experiment_dict[condition].get_sample_list() 
+        samples = experiment_dict[condition].get_sample_list()
         sample_list = sample_list + samples
 
-    # Differential expression 
-    diff_exp = process.DifferentialExpression(comparisons) 
+    # Differential expression
+    diff_exp = process.DifferentialExpression(comparisons)
     diff_exp.set_recipe(map_args.recipe)
     meta_file = diff_exp.create_metadata_file(sample_list, output_dir)
-    genome.add_genome_data('sample_metadata_file',meta_file)
+    genome.add_genome_data("sample_metadata_file", meta_file)
     if diffexp_flag:
         diffexp_import = process.DiffExpImport()
         diffexp_import.set_recipe(map_args.recipe)
         diff_exp.set_genome(genome)
-        diff_exp.run_differential_expression(output_dir,sample_list)
-        if genome.get_genome_type() == 'bacteria':
+        diff_exp.run_differential_expression(output_dir, sample_list)
+        if genome.get_genome_type() == "bacteria":
             diffexp_import.set_genome(genome)
-            diffexp_import.run_diff_exp_import(output_dir,map_args)
+            diffexp_import.run_diff_exp_import(output_dir, map_args)
 
     # Queries: subsystems, kegg
     # output files are used in creating figures
     if True:
         genome_data = process.GenomeData()
         genome_data.set_recipe(map_args.recipe)
-        if genome.get_genome_type() == 'bacteria':
+        if genome.get_genome_type() == "bacteria":
             genome_data.set_genome(genome)
-            genome_data.run_queries(output_dir,session)
+            genome_data.run_queries(output_dir, session)
             genome_data.create_system_figures(output_dir)
-    
+
     # call multiqc without any adjustments
     if not map_args.disable_reports:
         report_manager = report.ReportManager()
@@ -131,21 +141,29 @@ def main(genome, experiment_dict, tool_params, output_dir, comparisons, session,
         report_stats = {}
         sample_count = 0
         condition_count = 0
-        for condition in experiment_dict:       
+        for condition in experiment_dict:
             sample_count += len(experiment_dict[condition].get_sample_list())
-            if condition != 'no_condition':
+            if condition != "no_condition":
                 condition_count += 1
-        report_stats['num_samples'] = sample_count
-        report_stats['num_conditions'] = condition_count
+        report_stats["num_samples"] = sample_count
+        report_stats["num_conditions"] = condition_count
         # get recipe
-        report_stats['recipe'] = map_args.recipe 
+        report_stats["recipe"] = map_args.recipe
         report_manager.run_multiqc(output_dir)
-        report_manager.create_report(genome, output_dir, experiment_dict, report_stats, map_args.workspace_dir, diffexp_flag)
+        report_manager.create_report(
+            genome,
+            output_dir,
+            experiment_dict,
+            report_stats,
+            map_args.workspace_dir,
+            diffexp_flag,
+        )
 
-    # TODO: Add command output and status 
+    # TODO: Add command output and status
     # File cleanup in perl
     print("done")
     return True
+
 
 # sets up initial condition, sample, genome folder structure
 # folder stucture is: output_dir/condition/sample/genome
@@ -156,20 +174,22 @@ def setup(output_dir, experiment_dict, genome):
         print("Creating output directory: {0}".format(output_dir))
         os.mkdir(output_dir)
     else:
-        print("Output directory alread exists: {0}".format(output_dir))    
-    
-    # create subfolder list and add paths to relevant class objects 
+        print("Output directory alread exists: {0}".format(output_dir))
+
+    # create subfolder list and add paths to relevant class objects
     subfolder_list = []
     for condition in experiment_dict:
-        cond_path = os.path.abspath(os.path.join(output_dir,condition))
+        cond_path = os.path.abspath(os.path.join(output_dir, condition))
         experiment_dict[condition].set_path(cond_path)
         subfolder_list.append(cond_path)
         for sample in experiment_dict[condition].get_sample_list():
-            sample_path = os.path.abspath(os.path.join(experiment_dict[condition].get_path(),sample.get_id()))
+            sample_path = os.path.abspath(
+                os.path.join(experiment_dict[condition].get_path(), sample.get_id())
+            )
             sample.set_path(sample_path)
             subfolder_list.append(sample.get_path())
-            genome_path = sample.get_path() 
-            genome.create_path_entry(sample.get_id(),genome_path) 
+            genome_path = sample.get_path()
+            genome.create_path_entry(sample.get_id(), genome_path)
             subfolder_list.append(genome.get_sample_path(sample.get_id()))
 
     # create subfolders
@@ -182,14 +202,14 @@ def setup(output_dir, experiment_dict, genome):
             print("Subfolder already exists: {0}".format(folder))
 
     # create report images folder
-    report_img_folder = os.path.join(output_dir,'report_images/')
+    report_img_folder = os.path.join(output_dir, "report_images/")
     if not os.path.exists(report_img_folder):
         os.mkdir(report_img_folder)
-    genome.add_genome_data('report_img_path',report_img_folder)
+    genome.add_genome_data("report_img_path", report_img_folder)
 
     # TODO: genome_data checking, delete genome if not enough data??? Throw errors???
     # setup genome index objects
-    '''
+    """
     genome_links_dir = os.path.join(output_dir,"genome_links")
     if not os.path.exists(genome_links_dir):
         print("Creating {0}".format(genome_links_dir))
@@ -204,38 +224,64 @@ def setup(output_dir, experiment_dict, genome):
         else:
             print("{0} already exists".format(genome_data_dir))
         genome.setup_genome_database(genome_data_dir) 
-    '''
+    """
     genome.setup_genome_database()
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     # TODO: update help
-    parser.add_argument('--jfile',
-            help='json file for job {"reference_genome_id": "1310806.3", "experimental_conditions":\
+    parser.add_argument(
+        "--jfile",
+        help='json file for job {"reference_genome_id": "1310806.3", "experimental_conditions":\
                     ["c1_control", "c2_treatment"], "output_file": "rnaseq_baumanii_1505311", \
                     "recipe": "RNA-Rocket", "output_path": "/anwarren@patricbrc.org/home/test",\
                     "paired_end_libs": [{"read1": "/anwarren@patricbrc.org/home/rnaseq_test/MHB_R1.fq.gz",\
                     "read2": "/anwarren@patricbrc.org/home/rnaseq_test/MHB_R2.fq.gz", "condition": 1},\
                     {"read1": "/anwarren@patricbrc.org/home/rnaseq_test/MERO_75_R1.fq.gz",\
-                    "read2": "/anwarren@patricbrc.org/home/rnaseq_test/MERO_75_R2.fq.gz", "condition": 2}], "contrasts": [[1, 2]]}', required=True)
-    parser.add_argument('-o', help='output directory. defaults to current directory.', required=False, default=None)
-    parser.add_argument('-g', help='csv list of directories each containing all genome data: fna, gff, and hisat indices', required=True)
-    parser.add_argument('--sstring', help='json server string specifying api {"data_api":"url"}', required=False, default='{"data_api":"https://p3.theseed.org/services/data_api/genome_feature"}')
-    parser.add_argument('-p', help='tool parameters', required=False, type=str,default="{}")
-    parser.add_argument('-d', help='differential expression folder', required=False, default='.diff_exp')
+                    "read2": "/anwarren@patricbrc.org/home/rnaseq_test/MERO_75_R2.fq.gz", "condition": 2}], "contrasts": [[1, 2]]}',
+        required=True,
+    )
+    parser.add_argument(
+        "-o",
+        help="output directory. defaults to current directory.",
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
+        "-g",
+        help="csv list of directories each containing all genome data: fna, gff, and hisat indices",
+        required=True,
+    )
+    parser.add_argument(
+        "--sstring",
+        help='json server string specifying api {"data_api":"url"}',
+        required=False,
+        default='{"data_api":"https://p3.theseed.org/services/data_api/genome_feature"}',
+    )
+    parser.add_argument(
+        "-p", help="tool parameters", required=False, type=str, default="{}"
+    )
+    parser.add_argument(
+        "-d", help="differential expression folder", required=False, default=".diff_exp"
+    )
     # TODO:
-    # link to genome files (gff, fa)??? 
+    # link to genome files (gff, fa)???
     # link to hisat2 index
     # parameters as input json file OR inline
-    # unit testing parameters 
+    # unit testing parameters
 
     map_args = parser.parse_args()
     print("map_args:\n{0}".format(map_args))
 
     # set path to use correct version of samtools
-    os.environ['PATH'] = "/disks/patric-common/runtime/samtools-1.9/bin:"+os.environ['PATH']
-    os.environ['R_LIBS'] = "/disks/patric-common/runtime/lib/R/library:"+os.environ['R_LIBS']
-    print('R_LIBS path = {0}'.format(os.environ['R_LIBS']))
+    os.environ["PATH"] = (
+        "/disks/patric-common/runtime/samtools-1.9/bin:" + os.environ["PATH"]
+    )
+    os.environ["R_LIBS"] = (
+        "/disks/patric-common/runtime/lib/R/library:" + os.environ["R_LIBS"]
+    )
+    print("R_LIBS path = {0}".format(os.environ["R_LIBS"]))
 
     # output directory
     output_dir = map_args.o
@@ -246,30 +292,32 @@ if __name__ == "__main__":
     # load library
     job_data = None
     try:
-        with open(map_args.jfile, 'r') as job_handle:
+        with open(map_args.jfile, "r") as job_handle:
             job_data = json.load(job_handle)
     except Exception as e:
         print("Error in opening job json file:\n{0}".format(e))
-        sys.exit(-1) # Exception: issue in opening job json file
+        sys.exit(-1)  # Exception: issue in opening job json file
     if not job_data:
         print("job_data is null")
-        sys.exit(-1) # Exception: issue with loading job_data
+        sys.exit(-1)  # Exception: issue with loading job_data
 
     # Setup session
     s = requests.Session()
     try:
         authenticateByEnv(s)
-        print('authentication success')
+        print("authentication success")
     except Exception as e:
-        sys.stderr.write('Error during authentication, exiting:\n{0}'.format(e))
+        sys.stderr.write("Error during authentication, exiting:\n{0}".format(e))
         sys.exit(0)
 
     # load genome ids
     # genome_list = []
-    #for i in range(0,len(job_data["reference_genome_id"])):
-        #genome_list.append(experiment.Genome(job_data["reference_genome_id"][i],job_data["genome_type"][i],s))
+    # for i in range(0,len(job_data["reference_genome_id"])):
+    # genome_list.append(experiment.Genome(job_data["reference_genome_id"][i],job_data["genome_type"][i],s))
     # genome_list.append(experiment.Genome(job_data["reference_genome_id"],job_data["genome_type"],s))
-    genome = experiment.Genome(job_data["reference_genome_id"],job_data["genome_type"],s)
+    genome = experiment.Genome(
+        job_data["reference_genome_id"], job_data["genome_type"], s
+    )
 
     # DOWNLOAD GENOME DATA: remove from perl side
 
@@ -285,55 +333,61 @@ if __name__ == "__main__":
             data_key = None
             if f.endswith(".fna") or f.endswith(".fa") or f.endswith(".fasta"):
                 data_key = "fasta"
-            elif f.endswith(".gff"): # TODO: other annotation types?
+            elif f.endswith(".gff"):  # TODO: other annotation types?
                 data_key = "annotation"
             elif f.endswith(".ht2.tar"):
                 data_key = "hisat_index"
             else:
                 continue
             genome.set_genome_dir(genome_dir)
-            genome.add_genome_data(data_key,os.path.abspath(os.path.join(genome_dir,f)))
+            genome.add_genome_data(
+                data_key, os.path.abspath(os.path.join(genome_dir, f))
+            )
 
     # sample_list = [] # maybe don't store this, access samples by condition like in original
     experiment_dict = {}
     condition_list = []
-    for cond_str in job_data['experimental_conditions']:
-        cond_str = cond_str.replace(' ','_')
+    for cond_str in job_data["experimental_conditions"]:
+        cond_str = cond_str.replace(" ", "_")
         condition_list.append(cond_str)
         new_condition = experiment.Condition(cond_str)
         experiment_dict[cond_str] = new_condition
 
-    #paired_end_libs
-    if 'paired_end_libs' in job_data:
-        for paired_sample in job_data['paired_end_libs']:
-            if 'condition' in paired_sample:
-                condition = paired_sample['condition']
+    # paired_end_libs
+    if "paired_end_libs" in job_data:
+        for paired_sample in job_data["paired_end_libs"]:
+            if "condition" in paired_sample:
+                condition = paired_sample["condition"]
             else:
-                if 'no_condition' not in experiment_dict:
-                    no_condition = experiment.Condition('no_condition')
-                    experiment_dict['no_condition'] = no_condition
-                condition = 'no_condition'
-            condition = condition.replace(' ','_')
-            sample_reads = [paired_sample['read1'],paired_sample['read2']]
-            sample_id = paired_sample['sample_id'].replace(' ','_')
-            new_sample = experiment.Sample(sample_id,'paired',sample_reads,None,condition)
+                if "no_condition" not in experiment_dict:
+                    no_condition = experiment.Condition("no_condition")
+                    experiment_dict["no_condition"] = no_condition
+                condition = "no_condition"
+            condition = condition.replace(" ", "_")
+            sample_reads = [paired_sample["read1"], paired_sample["read2"]]
+            sample_id = paired_sample["sample_id"].replace(" ", "_")
+            new_sample = experiment.Sample(
+                sample_id, "paired", sample_reads, None, condition
+            )
             if condition:
                 experiment_dict[condition].add_sample(new_sample)
 
     # single_end_libs
-    if 'single_end_libs' in job_data:
-        for single_sample in job_data['single_end_libs']:
-            if 'condition' in single_sample:
-                condition = single_sample['condition']
+    if "single_end_libs" in job_data:
+        for single_sample in job_data["single_end_libs"]:
+            if "condition" in single_sample:
+                condition = single_sample["condition"]
             else:
-                if 'no_condition' not in experiment_dict:
-                    no_condition = experiment.Condition('no_condition')
-                    experiment_dict['no_condition'] = no_condition
-                condition = 'no_condition' 
-            condition = condition.replace(' ','_')
-            sample_read = [single_sample['read']]
-            sample_id = single_sample['sample_id'].replace(' ','_')
-            new_sample = experiment.Sample(sample_id,'single',sample_read,None,condition)
+                if "no_condition" not in experiment_dict:
+                    no_condition = experiment.Condition("no_condition")
+                    experiment_dict["no_condition"] = no_condition
+                condition = "no_condition"
+            condition = condition.replace(" ", "_")
+            sample_read = [single_sample["read"]]
+            sample_id = single_sample["sample_id"].replace(" ", "_")
+            new_sample = experiment.Sample(
+                sample_id, "single", sample_read, None, condition
+            )
             if condition:
                 experiment_dict[condition].add_sample(new_sample)
 
@@ -341,79 +395,99 @@ if __name__ == "__main__":
     # put sra-fastq files in <output_dir>/SRA_Fastq/
     # put sra-metadata files in <output_dir>/SRA_Meta/
     # set type to paired or single here
-    if 'srr_libs' in job_data:
-        sra_fastq_dir = os.path.join(output_dir,'SRA_Fastq')
-        sra_meta_dir = os.path.join(output_dir,'SRA_Meta')
+    if "srr_libs" in job_data:
+        sra_fastq_dir = os.path.join(output_dir, "SRA_Fastq")
+        sra_meta_dir = os.path.join(output_dir, "SRA_Meta")
         if not os.path.exists(sra_fastq_dir):
             os.mkdir(sra_fastq_dir)
         if not os.path.exists(sra_meta_dir):
             os.mkdir(sra_meta_dir)
-        for sra_sample in job_data['srr_libs']:
-            if 'condition' in sra_sample:
-                condition = sra_sample['condition']
+        for sra_sample in job_data["srr_libs"]:
+            if "condition" in sra_sample:
+                condition = sra_sample["condition"]
             else:
-                if 'no_condition' not in experiment_dict:
-                    no_condition = experiment.Condition('no_condition')
-                    experiment_dict['no_condition'] = no_condition
-                condition = 'no_condition' 
-            condition = condition.replace(' ','_')
-            srr_id = sra_sample['srr_accession'] 
-            meta_file = os.path.join(sra_meta_dir,srr_id+'_meta.txt')
+                if "no_condition" not in experiment_dict:
+                    no_condition = experiment.Condition("no_condition")
+                    experiment_dict["no_condition"] = no_condition
+                condition = "no_condition"
+            condition = condition.replace(" ", "_")
+            srr_id = sra_sample["srr_accession"]
+            meta_file = os.path.join(sra_meta_dir, srr_id + "_meta.txt")
             reads_dir = {}
             try:
-                subprocess.check_call(['p3-sra','--out',sra_fastq_dir,'--metadata-file',meta_file,'--id',srr_id])
-                with open(meta_file,'r') as meta_handle:
+                subprocess.check_call(
+                    [
+                        "p3-sra",
+                        "--out",
+                        sra_fastq_dir,
+                        "--metadata-file",
+                        meta_file,
+                        "--id",
+                        srr_id,
+                    ]
+                )
+                with open(meta_file, "r") as meta_handle:
                     job_meta = json.load(meta_handle)
-                    files = job_meta[0].get('files',[])
-                    for i,f in enumerate(files):
-                        if f.endswith('_2.fastq'):
-                            read2 = os.path.join(sra_fastq_dir,f)
-                            reads_dir['read2'] = read2
-                        elif f.endswith('_1.fastq'):
-                            read1 = os.path.join(sra_fastq_dir,f)
-                            reads_dir['read1'] = read1
-                        elif f.endswith('.fastq'):
-                            read = os.path.join(sra_fastq_dir,f)
-                            reads_dir['read'] = read
+                    files = job_meta[0].get("files", [])
+                    for i, f in enumerate(files):
+                        if f.endswith("_2.fastq"):
+                            read2 = os.path.join(sra_fastq_dir, f)
+                            reads_dir["read2"] = read2
+                        elif f.endswith("_1.fastq"):
+                            read1 = os.path.join(sra_fastq_dir, f)
+                            reads_dir["read1"] = read1
+                        elif f.endswith(".fastq"):
+                            read = os.path.join(sra_fastq_dir, f)
+                            reads_dir["read"] = read
                 missing_read = False
                 for read_key in reads_dir:
                     if not os.path.exists(reads_dir[read_key]):
-                        sys.stderr.write('Error: fastq file doesn\'t exist:\n{0}\n'.format(reads_dir[read_key]))
+                        sys.stderr.write(
+                            "Error: fastq file doesn't exist:\n{0}\n".format(
+                                reads_dir[read_key]
+                            )
+                        )
                         missing_read = True
                         continue
                 # TODO: exit or something?
                 if missing_read:
                     continue
-                if 'read2' in reads_dir:
-                    reads_list = [reads_dir['read1'],reads_dir['read2']]
-                    new_sample = experiment.Sample(srr_id,'paired',reads_list,None,condition)
+                if "read2" in reads_dir:
+                    reads_list = [reads_dir["read1"], reads_dir["read2"]]
+                    new_sample = experiment.Sample(
+                        srr_id, "paired", reads_list, None, condition
+                    )
                     if condition:
                         experiment_dict[condition].add_sample(new_sample)
-                else: #single end
-                    reads_list = [reads_dir['read']]
-                    new_sample = experiment.Sample(srr_id,'single',reads_list,None,condition)
+                else:  # single end
+                    reads_list = [reads_dir["read"]]
+                    new_sample = experiment.Sample(
+                        srr_id, "single", reads_list, None, condition
+                    )
                     if condition:
                         experiment_dict[condition].add_sample(new_sample)
-                
+
             except Exception as e:
-                sys.stderr.write('Error in downloading SRA ID {0}:\n{1}\n'.format(srr_id,e)) 
+                sys.stderr.write(
+                    "Error in downloading SRA ID {0}:\n{1}\n".format(srr_id, e)
+                )
                 # TODO: continue or exit??
                 sys.exit(-1)
 
     # TODO: tool parameters
     tool_params = json.loads(map_args.p)
-    print('tool_params = {0}'.format(tool_params))
-    
+    print("tool_params = {0}".format(tool_params))
+
     # TODO:
     # finish samples object list
     # load comparisons object: comparison_list
 
     # TODO:
     #   - check if diffexp is turned on, turn off if need be
-    comparisons = experiment.Comparison() 
+    comparisons = experiment.Comparison()
     for con in job_data["contrasts"]:
-        con = [x.replace(' ','_') for x in con]
-        comparisons.add_contrast(con[0],con[1])
+        con = [x.replace(" ", "_") for x in con]
+        comparisons.add_contrast(con[0], con[1])
 
     # TODO: Check if job_data contains 'cufflinks' flag: if true, run old pipeline
 
@@ -421,22 +495,22 @@ if __name__ == "__main__":
     os.chdir(output_dir)
 
     # set recipe in map_args
-    map_args.recipe = job_data['recipe'] 
+    map_args.recipe = job_data["recipe"]
 
     # set trimming in map_args
-    if 'trimming' in job_data:
-        map_args.trimming = job_data['trimming']
+    if "trimming" in job_data:
+        map_args.trimming = job_data["trimming"]
     else:
         map_args.trimming = True
 
     # set report variable
-    if 'disable_reports' in job_data:
-        map_args.disable_reports = job_data['disable_reports']
+    if "disable_reports" in job_data:
+        map_args.disable_reports = job_data["disable_reports"]
     else:
         map_args.disable_reports = False
 
     # workspace dir for links
-    map_args.workspace_dir = job_data['output_path']
+    map_args.workspace_dir = job_data["output_path"]
 
     # If not cufflinks, run pipeline
     main(genome, experiment_dict, tool_params, output_dir, comparisons, s, map_args)

--- a/scripts/run_rnaseq.py
+++ b/scripts/run_rnaseq.py
@@ -28,7 +28,7 @@ def main(
     setup(output_dir, experiment_dict, genome)
     diffexp_flag = comparisons.check_diffexp()
 
-    ### process data independently of genomes
+    # process data independently of genomes
     # Fastqc
     preprocess = process.Preprocess()
     for condition in experiment_dict:
@@ -42,7 +42,7 @@ def main(
             for sample in experiment_dict[condition].get_sample_list():
                 preprocess.run_trimming(sample, 8)
 
-    ### Sampled align against genome
+    # Sampled align against genome
     # TODO: assess strandedness with one genome?
     alignment = process.Alignment()
     alignment.set_genome(genome)
@@ -50,7 +50,7 @@ def main(
         for sample in experiment_dict[condition].get_sample_list():
             alignment.run_sample_alignment(sample, 8)
 
-    ### Align against genome
+    # Align against genome
     alignment.set_genome(genome)
     alignment_all_good = True
     for condition in experiment_dict:
@@ -223,7 +223,7 @@ def setup(output_dir, experiment_dict, genome):
             os.mkdir(genome_data_dir)
         else:
             print("{0} already exists".format(genome_data_dir))
-        genome.setup_genome_database(genome_data_dir) 
+        genome.setup_genome_database(genome_data_dir)
     """
     genome.setup_genome_database()
 


### PR DESCRIPTION
@olsonanl @aswarren 
We can try to run flake8 to catch issues where we might not have (properly) used an intended variable, et. al.

I did some cleanup, to reduce the noise, and still get the following issues:

```
./lib/process.py:224:17: E722 do not use bare 'except'
./lib/process.py:650:9: F841 local variable 'e' is assigned to but never used
./lib/process.py:747:9: F841 local variable 'threads' is assigned to but never used
./lib/process.py:805:17: F841 local variable 'af_headers' is assigned to but never used
./lib/process.py:822:25: W503 line break before binary operator
./lib/process.py:823:25: W503 line break before binary operator
./lib/process.py:1414:13: W503 line break before binary operator
./lib/process.py:1415:13: W503 line break before binary operator
./lib/process.py:1416:13: W503 line break before binary operator
./lib/process.py:1417:13: W503 line break before binary operator
./lib/process.py:1418:13: W503 line break before binary operator
./lib/process.py:1714:17: F841 local variable 'read_parts1' is assigned to but never used
./lib/process.py:1715:17: F841 local variable 'read_parts2' is assigned to but never used
./lib/process.py:1721:17: F841 local variable 'read_parts' is assigned to but never used
./lib/report.py:142:9: F841 local variable 'url' is assigned to but never used
./lib/report.py:156:13: F841 local variable 'e' is assigned to but never used
./lib/report.py:174:13: F841 local variable 'e' is assigned to but never used
./lib/report.py:300:9: F841 local variable 'seqtk_ref' is assigned to but never used
./scripts/expression_transform_bvbrc.py:245:17: W503 line break before binary operator
./scripts/expression_transform_bvbrc.py:246:17: W503 line break before binary operator
./scripts/expression_transform_bvbrc.py:247:17: W503 line break before binary operator
./scripts/expression_transform_bvbrc.py:248:17: W503 line break before binary operator
./scripts/expression_transform_bvbrc.py:290:9: W503 line break before binary operator
./scripts/expression_transform_bvbrc.py:389:13: F841 local variable 'meta_key' is assigned to but never used
./scripts/expression_transform_bvbrc.py:399:9: E722 do not use bare 'except'
./scripts/expression_transform_bvbrc.py:574:5: F841 local variable 'valid_formats' is assigned to but never used
./scripts/expression_transform_bvbrc.py:575:5: F841 local variable 'valid_setups' is assigned to but never used
./scripts/expression_transform_bvbrc.py:619:5: F841 local variable 'user_parse' is assigned to but never used
./scripts/expression_transform_bvbrc.py:620:5: F841 local variable 'server_parse' is assigned to but never used
./scripts/expression_transform_bvbrc.py:621:5: F841 local variable 'parse_server' is assigned to but never used
./scripts/expression_transform_bvbrc.py:629:5: E722 do not use bare 'except'
./scripts/expression_transform_bvbrc.py:639:5: E722 do not use bare 'except'
./scripts/expression_transform_bvbrc.py:658:13: W503 line break before binary operator
./scripts/expression_transform_bvbrc.py:661:13: W503 line break before binary operator
./scripts/rnaseqPrepDE.py:216:40: E741 ambiguous variable name 'l'
./scripts/rnaseqPrepDE.py:224:17: E722 do not use bare 'except'
./scripts/rnaseqPrepDE.py:318:13: E741 ambiguous variable name 'l'
./scripts/rnaseqPrepDE.py:353:40: F821 undefined name 'coverage'
./scripts/run_rnaseq.py:4:16: E401 multiple imports on one line
./scripts/run_rnaseq.py:101:5: F841 local variable 'condition_output_list' is assigned to but never used
```

We can add more (comma-separated) codes to the [ignore string](https://github.com/bdklahn/bvbrc_rnaseq/blob/a5866f459dcee7f96d2bd877d00ad284536887d0/.github/workflows/flake8_lint.yml#L19) (than just ignoring long lines), to reduce the noise. But I kinda like a prompt to clean up code. Messy code takes longer to develop and debug. 