### PR TITLE
Adding null file path check

### DIFF
--- a/lib/report.py
+++ b/lib/report.py
@@ -241,7 +241,7 @@ class ReportManager:
                         genome.get_id() + "_align_stats"
                     )
                     error_list.append("<p>")
-                    if os.path.exists(align_file):
+                    if align_file and  os.path.exists(align_file):
                         with open(align_file, "r") as af:
                             align_text = af.readlines()
                             # error_list.append('\n'.join(align_text))

--- a/service-scripts/App-RNASeq.pl
+++ b/service-scripts/App-RNASeq.pl
@@ -165,7 +165,7 @@ sub process_rnaseq {
     if ($called_localize_params) {
         remove_localized_params($tmpdir, $params); 
     }
-    die 'here\n';
+
     if ($disable_workspace_upload) {
         die "disable_workspace_upload is true: terminating job before upload\n";
     }

--- a/service-scripts/App-RNASeq.pl
+++ b/service-scripts/App-RNASeq.pl
@@ -165,7 +165,7 @@ sub process_rnaseq {
     if ($called_localize_params) {
         remove_localized_params($tmpdir, $params); 
     }
-
+    die 'here\n';
     if ($disable_workspace_upload) {
         die "disable_workspace_upload is true: terminating job before upload\n";
     }


### PR DESCRIPTION
- Adding null file path check: cause of job failures in certain cases