### PR TITLE
Changing list to hash

### DIFF
--- a/service-scripts/App-RNASeq.pl
+++ b/service-scripts/App-RNASeq.pl
@@ -767,16 +767,20 @@ sub run_cmd {
 
 sub params_to_exps {
     my ($params) = @_;
-    my @exps;
+    my %exps;
     for (@{$params->{paired_end_libs}}) {
-        my $index = $_->{condition} - 1;
-        $index = 0 if $index < 0;
-        push @{$exps[$index]}, [ $_->{read1}, $_->{read2} ];
+        my $condition = $_->{condition};
+        if (!exists($exps{$condition})) {
+            $exps{$condition} = [];
+        }
+        push @{$exps[$condition]}, [ $_->{read1}, $_->{read2} ];
     }
     for (@{$params->{single_end_libs}}) {
-        my $index = $_->{condition} - 1;
-        $index = 0 if $index < 0;
-        push @{$exps[$index]}, [ $_->{read} ];
+        my $condition = $_->{condition};
+        if (!exists($exps{$condition})) {
+            $exps{$condition} = [];
+        }
+        push @{$exps[$condition]}, [ $_->{read} ];
     }
     return \@exps;
 }

--- a/service-scripts/App-RNASeq.pl
+++ b/service-scripts/App-RNASeq.pl
@@ -165,7 +165,7 @@ sub process_rnaseq {
     if ($called_localize_params) {
         remove_localized_params($tmpdir, $params); 
     }
-    die "here\n";
+
     if ($disable_workspace_upload) {
         die "disable_workspace_upload is true: terminating job before upload\n";
     }
@@ -315,6 +315,8 @@ sub run_bvbrc_rnaseq {
     #my $unit_test = defined($params->{unit_test}) ? $params->{unit_test} : undef;
     
     print "Run rna_rocket ", Dumper(%exps, $labels, $tmpdir);
+    
+    die "here\n";
     
     # my $rocket = "/home/fangfang/programs/Prok-tuxedo/prok_tuxedo.py";
     my $rocket = "run_rnaseq";

--- a/service-scripts/App-RNASeq.pl
+++ b/service-scripts/App-RNASeq.pl
@@ -165,7 +165,7 @@ sub process_rnaseq {
     if ($called_localize_params) {
         remove_localized_params($tmpdir, $params); 
     }
-
+    die "here\n";
     if ($disable_workspace_upload) {
         die "disable_workspace_upload is true: terminating job before upload\n";
     }

--- a/service-scripts/App-RNASeq.pl
+++ b/service-scripts/App-RNASeq.pl
@@ -316,8 +316,6 @@ sub run_bvbrc_rnaseq {
     
     print "Run rna_rocket ", Dumper(%exps, $labels, $tmpdir);
     
-    die "here\n";
-    
     # my $rocket = "/home/fangfang/programs/Prok-tuxedo/prok_tuxedo.py";
     my $rocket = "run_rnaseq";
     verify_cmd($rocket);

--- a/service-scripts/App-RNASeq.pl
+++ b/service-scripts/App-RNASeq.pl
@@ -782,7 +782,7 @@ sub params_to_exps {
         }
         push @{$exps[$condition]}, [ $_->{read} ];
     }
-    return \@exps;
+    return %exps;
 }
 
 # TODO: add removing srr libs

--- a/service-scripts/App-RNASeq.pl
+++ b/service-scripts/App-RNASeq.pl
@@ -773,14 +773,14 @@ sub params_to_exps {
         if (!exists($exps{$condition})) {
             $exps{$condition} = [];
         }
-        push @{$exps[$condition]}, [ $_->{read1}, $_->{read2} ];
+        push @{$exps{$condition}}, [ $_->{read1}, $_->{read2} ];
     }
     for (@{$params->{single_end_libs}}) {
         my $condition = $_->{condition};
         if (!exists($exps{$condition})) {
             $exps{$condition} = [];
         }
-        push @{$exps[$condition]}, [ $_->{read} ];
+        push @{$exps{$condition}}, [ $_->{read} ];
     }
     return %exps;
 }

--- a/service-scripts/App-RNASeq.pl
+++ b/service-scripts/App-RNASeq.pl
@@ -302,7 +302,7 @@ sub run_bvbrc_rnaseq {
     
     my $outdir = "$tmpdir";
     
-    my $exps     = params_to_exps($params);
+    my %exps     = params_to_exps($params);
     my $labels   = $params->{experimental_conditions};
     my $ref_id   = $params->{reference_genome_id} or die "Reference genome is required\n";
     my $output_name = $params->{output_file} or die "Output name is required\n";
@@ -314,7 +314,7 @@ sub run_bvbrc_rnaseq {
     my $ref_dir  = prepare_ref_data_rocket($ref_id, $tmpdir, $host, $host_ftp);
     #my $unit_test = defined($params->{unit_test}) ? $params->{unit_test} : undef;
     
-    print "Run rna_rocket ", Dumper($exps, $labels, $tmpdir);
+    print "Run rna_rocket ", Dumper(%exps, $labels, $tmpdir);
     
     # my $rocket = "/home/fangfang/programs/Prok-tuxedo/prok_tuxedo.py";
     my $rocket = "run_rnaseq";


### PR DESCRIPTION
- Various parameters are dumped to stdout during the setup of rnaseq
- Changing a parameter dump to a hash instead of list, necessary after changing experimental conditions from integers to strings